### PR TITLE
Option to skip test that parse ontologies. Using TESTOPTS="--skip-parsin...

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'rake/testtask'
+require 'pry'
 
 Rake::TestTask.new do |t|
   t.libs = []
@@ -21,4 +22,13 @@ Rake::TestTask.new do |t|
   t.libs = []
   t.name = "test:serializer"
   t.test_files = FileList['test/serializer/test*.rb']
+end
+
+namespace :test do
+  if (not (ENV['TESTOPTS'].index "--skip-parsing").nil?)
+    test_opts = ENV['TESTOPTS'].dup
+    test_opts["--skip-parsing"]=""
+    ENV['TESTOPTS'] = test_opts
+    ENV['SKIP_PARSING'] = "please" #be nice
+  end
 end

--- a/test/models/test_class.rb
+++ b/test/models/test_class.rb
@@ -7,6 +7,8 @@ class TestClassModel < LinkedData::TestOntologyCommon
   end
 
   def test_terms_custom_props
+    return if ENV["SKIP_PARSING"]
+
     acr = "CSTPROPS"
     init_test_ontology_msotest acr
     os = LinkedData::Models::OntologySubmission.find(acr + '+' + 1.to_s)

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -20,6 +20,7 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
   end
 
   def test_valid_ontology
+    return if ENV["SKIP_PARSING"]
 
     acronym = "SNOMED-TST"
     name = "SNOMED-CT TEST"
@@ -50,6 +51,7 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
   end
 
   def test_sanity_check_single_file_submission
+    return if ENV["SKIP_PARSING"]
 
     acronym = "BRO"
     name = "Biomedical Resource Ontology"
@@ -76,6 +78,7 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
 
 
   def test_sanity_check_zip
+    return if ENV["SKIP_PARSING"]
 
     acronym = "RADTEST"
     name = "RADTEST Bla"
@@ -112,6 +115,8 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
   end
 
   def test_duplicated_file_names
+    return if ENV["SKIP_PARSING"]
+
     acronym = "DUPTEST"
     name = "DUPTEST Bla"
     ontologyFile = "./test/data/ontology_files/ont_dup_names.zip"
@@ -130,6 +135,8 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
   end
 
   def test_submission_parse
+    return if ENV["SKIP_PARSING"]
+
     acronym = "BROTEST"
     name = "BROTEST Bla"
     ontologyFile = "./test/data/ontology_files/BRO_v3.2.owl"
@@ -173,6 +180,7 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
   end
 
   def test_submission_parse_zip
+    return if ENV["SKIP_PARSING"]
 
     acronym = "RADTEST"
     name = "RADTEST Bla"
@@ -227,6 +235,8 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
   end
 
   def test_custom_property_generation
+    return if ENV["SKIP_PARSING"]
+
     acr = "CUSTOMPROPTEST"
     init_test_ontology_msotest acr
 

--- a/test/parser/test_owl_api_command.rb
+++ b/test/parser/test_owl_api_command.rb
@@ -4,6 +4,8 @@ require 'logger'
 class TestOWLApi < LinkedData::TestCase
 
   def test_command_owl_api_single_file
+    return if ENV["SKIP_PARSING"]
+
     output_repo =  "test/data/ontology_files/repo/bro/10/output"
     input_file = "test/data/ontology_files/BRO_v3.2.owl"
     LinkedData::Parser.logger =  Logger.new(STDOUT)
@@ -15,6 +17,8 @@ class TestOWLApi < LinkedData::TestCase
   end
 
   def test_command_KO_output
+    return if ENV["SKIP_PARSING"]
+
     output_repo =  "/var/log/xxxxx"
     input_file = "test/data/ontology_files/"
     owlapi = LinkedData::Parser::OWLAPICommand.new(input_file,output_repo,nil)
@@ -26,6 +30,8 @@ class TestOWLApi < LinkedData::TestCase
     end
   end
   def test_command_KO_input
+    return if ENV["SKIP_PARSING"]
+
     output_repo =  "/var/log/xxxxx"
     input_file = "test/data/ontology_files/aaaa"
     owlapi = LinkedData::Parser::OWLAPICommand.new(input_file,output_repo,nil)
@@ -38,6 +44,8 @@ class TestOWLApi < LinkedData::TestCase
   end
 
   def test_command_KO_master
+    return if ENV["SKIP_PARSING"]
+
     output_repo =  "/var/log/xxxxx"
     input_file = "test/data/ontology_files/radlex_owl_v3.0.1.zip"
     owlapi = LinkedData::Parser::OWLAPICommand.new(input_file,output_repo,nil)


### PR DESCRIPTION
To use include TESTOPTS="--skip-parsing"

I have decided that, by default, it is better to run this tests by default. Otherwise we will never run them.

This should close #12.
