### PR TITLE
serializer: next when object method fails

### DIFF
--- a/lib/ontologies_linked_data/monkeypatches/object.rb
+++ b/lib/ontologies_linked_data/monkeypatches/object.rb
@@ -42,7 +42,11 @@ class Object
 
     # Add methods
     methods.each do |method|
-      hash[method] = self.send(method.to_s) if self.respond_to?(method) rescue next
+      begin
+        hash[method] = self.send(method.to_s) if self.respond_to?(method)
+      rescue Exception => e
+        next
+      end
     end
 
     # Get rid of everything except the 'only'


### PR DESCRIPTION
@palexander so the serializer recursively calls `properties` for children when doing `include_param=all`

You have a `rescue next` that still does not catch the exception that Goo throws. My modification grabs the exception and continues.

The question here is if we should be loading `properties` for `children`.
