### PR TITLE
fix a bug for groups-slices synchronisation

### DIFF
--- a/lib/ontologies_linked_data/models/slice.rb
+++ b/lib/ontologies_linked_data/models/slice.rb
@@ -21,11 +21,11 @@ module LinkedData::Models
       return [:acronym_value_validator, nil]
     end
 
+    # Check to make sure each group has a corresponding slice (and ontologies match)
     def self.synchronize_groups_to_slices
-      # Check to make sure each group has a corresponding slice (and ontologies match)
       groups = LinkedData::Models::Group.where.include(LinkedData::Models::Group.attributes(:all)).all
       groups.each do |g|
-        slice = self.find(g.acronym).include(LinkedData::Models::Slice.attributes(:all)).first
+        slice = self.find(g.acronym.downcase.gsub(" ", "_")).include(LinkedData::Models::Slice.attributes(:all)).first
         if slice
           slice.ontologies = g.ontologies
           slice.save if slice.valid?


### PR DESCRIPTION
fix a bug where slices were created by downcasing groups acronym. But when trying to retrieve them to update them, the groups acronym were not downcased so the slices were not found