### PR TITLE
Add java heap size configuration variable

### DIFF
--- a/config/config.rb.sample
+++ b/config/config.rb.sample
@@ -6,7 +6,7 @@ LinkedData.config do |config|
   config.repository_folder = "./test/data/ontology_files/repo"
   config.rest_url_prefix   = "http://data.bioontology.org/"
   config.enable_security   = false
-
+  config.java_max_heap_size         = '10240M'
   #PURL server config parameters
   config.enable_purl            = false
   config.purl_host              = "purl.bioontology.org"

--- a/lib/ontologies_linked_data/config/config.rb
+++ b/lib/ontologies_linked_data/config/config.rb
@@ -15,19 +15,21 @@ module LinkedData
     overide_connect_goo = false
 
     # Set defaults
-    @settings.goo_backend_name              ||= "4store"
+    @settings.goo_backend_name              ||= '4store'
     @settings.goo_port                      ||= 9000
-    @settings.goo_host                      ||= "localhost"
-    @settings.goo_path_query                ||= "/sparql/"
-    @settings.goo_path_data                 ||= "/data/"
-    @settings.goo_path_update               ||= "/update/"
-    @settings.search_server_url             ||= "http://localhost:8983/solr/term_search_core1"
-    @settings.property_search_server_url    ||= "http://localhost:8983/solr/prop_search_core1"
-    @settings.repository_folder             ||= "./test/data/ontology_files/repo"
-    @settings.rest_url_prefix               ||= "http://data.bioontology.org/"
+    @settings.goo_host                      ||= 'localhost'
+    @settings.goo_path_query                ||= '/sparql/'
+    @settings.goo_path_data                 ||= '/data/'
+    @settings.goo_path_update               ||= '/update/'
+    @settings.search_server_url             ||= 'http://localhost:8983/solr/term_search_core1'
+    @settings.property_search_server_url    ||= 'http://localhost:8983/solr/prop_search_core1'
+    @settings.repository_folder             ||= './test/data/ontology_files/repo'
+    @settings.rest_url_prefix                ||= 'http://data.bioontology.org/'
     @settings.enable_security               ||= false
     @settings.enable_slices                 ||= false
 
+    # Java/JVM options
+    @settings.java_max_heap_size            ||= '10240M'
     ### these params should be not ussed any more
     # removed so that dependencies shout
     #
@@ -35,47 +37,47 @@ module LinkedData
     # @settings.redis_port                    ||= 6379
     # ###
 
-    @settings.ui_host                       ||= "bioportal.bioontology.org"
+    @settings.ui_host                       ||= 'bioportal.bioontology.org'
     @settings.replace_url_prefix            ||= false
-    @settings.id_url_prefix                 ||= "http://data.bioontology.org/"
+    @settings.id_url_prefix                 ||= 'http://data.bioontology.org/'
     @settings.queries_debug                 ||= false
     @settings.enable_monitoring             ||= false
-    @settings.cube_host                     ||= "localhost"
+    @settings.cube_host                     ||= 'localhost'
     @settings.cube_port                     ||= 1180
 
     # Caching http
     @settings.enable_http_cache             ||= false
-    @settings.http_redis_host               ||= "localhost"
+    @settings.http_redis_host               ||= 'localhost'
     @settings.http_redis_port               ||= 6379
 
     #Caching goo
-    @settings.goo_redis_host                ||= "localhost"
+    @settings.goo_redis_host                ||= 'localhost'
     @settings.goo_redis_port                ||= 6379
 
     #Ontology Analytics Redis
-    @settings.ontology_analytics_redis_host ||= "localhost"
+    @settings.ontology_analytics_redis_host ||= 'localhost'
     @settings.ontology_analytics_redis_port ||= 6379
 
     # PURL server config parameters
     @settings.enable_purl                   ||= false
-    @settings.purl_host                     ||= "purl.bioontology.org"
+    @settings.purl_host                     ||= 'purl.bioontology.org'
     @settings.purl_port                     ||= 80
-    @settings.purl_username                 ||= ""
-    @settings.purl_password                 ||= ""
-    @settings.purl_maintainers              ||= ""
-    @settings.purl_target_url_prefix        ||= "http://bioportal.bioontology.org"
+    @settings.purl_username                 ||= ''
+    @settings.purl_password                 ||= ''
+    @settings.purl_maintainers              ||= ''
+    @settings.purl_target_url_prefix        ||= 'http://bioportal.bioontology.org'
 
     # Email settings
     @settings.enable_notifications          ||= false
-    @settings.email_sender                  ||= "admin@example.org" # Default sender for emails
-    @settings.email_override                ||= "test.email@example.org" # By default, all email gets sent here. Disable with email_override_disable.
+    @settings.email_sender                  ||= 'admin@example.org' # Default sender for emails
+    @settings.email_override                ||= 'test.email@example.org' # By default, all email gets sent here. Disable with email_override_disable.
     @settings.email_disable_override        ||= false
-    @settings.smtp_host                     ||= "localhost"
+    @settings.smtp_host                     ||= 'localhost'
     @settings.smtp_port                     ||= 25
-    @settings.smtp_user                     ||= "user"
-    @settings.smtp_password                 ||= "password"
+    @settings.smtp_user                     ||= 'user'
+    @settings.smtp_password                 ||= 'password'
     @settings.smtp_auth_type                ||= :none # :none, :plain, :login, :cram_md5
-    @settings.smtp_domain                   ||= "localhost.localhost"
+    @settings.smtp_domain                   ||= 'localhost.localhost'
     @settings.enable_starttls_auto          ||= false # set to true for use with gmail
 
     # number of times to retry a query when empty records are returned
@@ -89,19 +91,19 @@ module LinkedData
 
     unless @settings.redis_host.nil?
       puts "Error: 'redis_host' is not a valid conf parameter."
-      puts "        Redis databases were split into multiple hosts (09/22/13)."
-      raise Exception, "redis_host is not a valid conf parameter."
+      puts '        Redis databases were split into multiple hosts (09/22/13).'
+      raise Exception, 'redis_host is not a valid conf parameter.'
     end
 
     # Check to make sure url prefix has trailing slash
-    @settings.rest_url_prefix = @settings.rest_url_prefix + "/" unless @settings.rest_url_prefix[-1].eql?("/")
+    @settings.rest_url_prefix = @settings.rest_url_prefix + '/' unless @settings.rest_url_prefix[-1].eql?('/')
 
     puts "(LD) >> Using rdf store #{@settings.goo_host}:#{@settings.goo_port}"
     puts "(LD) >> Using term search server at #{@settings.search_server_url}"
     puts "(LD) >> Using property search server at #{@settings.property_search_server_url}"
-    puts "(LD) >> Using HTTP Redis instance at "+
+    puts '(LD) >> Using HTTP Redis instance at '+
             "#{@settings.http_redis_host}:#{@settings.http_redis_port}"
-    puts "(LD) >> Using Goo Redis instance at "+
+    puts '(LD) >> Using Goo Redis instance at '+
             "#{@settings.goo_redis_host}:#{@settings.goo_redis_port}"
 
     connect_goo unless overide_connect_goo

--- a/lib/ontologies_linked_data/diff/bubastis_diff.rb
+++ b/lib/ontologies_linked_data/diff/bubastis_diff.rb
@@ -83,7 +83,7 @@ module LinkedData
         end
         errors_log = File.join([@output_repo, "bubastis_diff_errors.log"])
         File.delete errors_log if File.exist? errors_log
-        java_cmd = "java -DentityExpansionLimit=1500000 -Xmx5120M -jar #{@bubastis_jar_path} #{options.join(' ')}"
+        java_cmd = "java -DentityExpansionLimit=1500000 -Xmx#{LinkedData.settings.java_max_heap_size} -jar #{@bubastis_jar_path} #{options.join(' ')}"
         Diff.logger.info("Java call [#{java_cmd}]")
         stdout,stderr,status = Open3.capture3(java_cmd)
         if not status.success?

--- a/lib/ontologies_linked_data/diff/bubastis_diff.rb
+++ b/lib/ontologies_linked_data/diff/bubastis_diff.rb
@@ -43,6 +43,7 @@ module LinkedData
         @input_fileNew = input_fileNew
         @output_repo = File.expand_path(@input_fileNew).gsub(File.basename(@input_fileNew),'')
         @file_diff_path = nil
+        @java_heap_size = LinkedData.settings.java_max_heap_size
       end
 
       def setup_environment
@@ -83,7 +84,7 @@ module LinkedData
         end
         errors_log = File.join([@output_repo, "bubastis_diff_errors.log"])
         File.delete errors_log if File.exist? errors_log
-        java_cmd = "java -DentityExpansionLimit=1500000 -Xmx#{LinkedData.settings.java_max_heap_size} -jar #{@bubastis_jar_path} #{options.join(' ')}"
+        java_cmd = "java -DentityExpansionLimit=1500000 -Xmx#{@java_heap_size} -jar #{@bubastis_jar_path} #{options.join(' ')}"
         Diff.logger.info("Java call [#{java_cmd}]")
         stdout,stderr,status = Open3.capture3(java_cmd)
         if not status.success?

--- a/lib/ontologies_linked_data/parser/owlapi.rb
+++ b/lib/ontologies_linked_data/parser/owlapi.rb
@@ -21,6 +21,7 @@ module LinkedData
         @file_triples_path = nil
         @missing_imports = nil
         @reasoning = true
+        @java_heap_size = LinkedData.settings.java_max_heap_size
       end
 
       def setup_environment
@@ -71,7 +72,7 @@ module LinkedData
         if File.exist? errors_log
           File.delete errors_log
         end
-        command_call = "java -DentityExpansionLimit=2500000 -Xmx#{LinkedData.settings.java_max_heap_size} -jar #{@owlapi_wrapper_jar_path} #{options}"
+        command_call = "java -DentityExpansionLimit=2500000 -Xmx#{@java_heap_size} -jar #{@owlapi_wrapper_jar_path} #{options}"
         @logger.info("Java call [#{command_call}]")
         Open3.popen3(command_call) do |i,o,e,w|
           i.close

--- a/lib/ontologies_linked_data/parser/owlapi.rb
+++ b/lib/ontologies_linked_data/parser/owlapi.rb
@@ -71,7 +71,7 @@ module LinkedData
         if File.exist? errors_log
           File.delete errors_log
         end
-        command_call = "java -DentityExpansionLimit=2500000 -Xmx10240M -jar #{@owlapi_wrapper_jar_path} #{options}"
+        command_call = "java -DentityExpansionLimit=2500000 -Xmx#{LinkedData.settings.java_max_heap_size} -jar #{@owlapi_wrapper_jar_path} #{options}"
         @logger.info("Java call [#{command_call}]")
         Open3.popen3(command_call) do |i,o,e,w|
           i.close


### PR DESCRIPTION
Fix https://github.com/ncbo/ontologies_linked_data/issues/124

Changes : 
1. Added the [configuration variable for setting owlapi_wrapper java heap size](https://github.com/ncbo/ontologies_linked_data/commit/bad5823a02cf873f5c9e01c091022b173745a55b#diff-00a22c82e3eee2878d34f8afa7c7a922779a9c697192e446b0575658f7f0c852R32)
2. Updated the config sample
3. Updated owlapi and bubastis to use it

Our original issue at Agroportal : https://github.com/ontoportal-lirmm/ontologies_linked_data/issues/15