### PR TITLE
Fix: remove submission directory and files on submission delete

### DIFF
--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -1371,7 +1371,7 @@ eos
         end
 
         # delete the folder and files
-        FileUtils.remove_dir(self.data_folder)
+        FileUtils.remove_dir(self.data_folder) if Dir.exist?(self.data_folder)
       end
 
       def roots(extra_include=nil, page=nil, pagesize=nil)

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -1369,6 +1369,9 @@ eos
             end
           end
         end
+
+        # delete the folder and files
+        FileUtils.remove_dir(self.data_folder)
       end
 
       def roots(extra_include=nil, page=nil, pagesize=nil)

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1025,4 +1025,21 @@ eos
     assert_equal 133, metrics.classes
   end
 
+  def test_submission_delete_remove_files
+    #This one has resources wih accents.
+    submission_parse("ONTOMATEST",
+                     "OntoMA TEST",
+                     "./test/data/ontology_files/OntoMA.1.1_vVersion_1.1_Date__11-2011.OWL", 15,
+                     process_rdf: true, index_search: true,
+                     run_metrics: false, reasoning: true)
+
+    sub = LinkedData::Models::OntologySubmission.where(ontology: [acronym: "ONTOMATEST"],
+                                                       submissionId: 15)
+                                                .first
+
+    data_folder = sub.data_folder
+    assert Dir.exist? data_folder
+    sub.delete
+    assert !Dir.exist?(data_folder)
+  end
 end


### PR DESCRIPTION
At Agroportal we had a [use case](https://github.com/agroportal/documentation/issues/167), where we had an ontology updating by error each day from its remote URL, because of that we had a lot of undesirable submissions that we wanted to remove.  

But when we tried to remove it we found that the submissions are removed from the store but not their files. This PL is fixing that,

