### PR TITLE
Feature: use the resolved namespace instead of the default vocabulary in the @context

### DIFF
--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -58,7 +58,8 @@ module LinkedData
             predicate = {"@id" => linked_model.type_uri.to_s, "@type" => "@id"}
           elsif current_cls.model_settings[:attributes][attr][:namespace]
             # predicate with custom namespace
-            predicate = "#{Goo.vocabulary[current_cls.model_settings[:attributes][attr][:namespace]].to_s}#{attr}"
+            # if the namespace can be resolved by the namespaces added in Goo then it will be resolved.
+            predicate = "#{Goo.vocabulary(current_cls.model_settings[:attributes][attr][:namespace]).to_s}#{attr}"
           end
           hash[attr] = predicate unless predicate.nil?
         end

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -52,14 +52,15 @@ module LinkedData
             linked_model = current_cls.model_settings[:range][attr]
           end
 
-          predicate = nil
           if linked_model && linked_model.ancestors.include?(Goo::Base::Resource) && !embedded?(object, attr)
             # linked object
             predicate = {"@id" => linked_model.type_uri.to_s, "@type" => "@id"}
-          elsif current_cls.model_settings[:attributes][attr][:namespace]
+          else
+            # use the original predicate property if set
+            predicate_attr =  current_cls.model_settings[:attributes][attr][:property] || attr
             # predicate with custom namespace
             # if the namespace can be resolved by the namespaces added in Goo then it will be resolved.
-            predicate = "#{Goo.vocabulary(current_cls.model_settings[:attributes][attr][:namespace]).to_s}#{attr}"
+            predicate = "#{Goo.vocabulary(current_cls.model_settings[:attributes][attr][:namespace])&.to_s}#{predicate_attr}"
           end
           hash[attr] = predicate unless predicate.nil?
         end

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -30,7 +30,7 @@ module LinkedData
           # Generate context
           if current_cls.ancestors.include?(Goo::Base::Resource) && !current_cls.embedded?
             if generate_context?(options)
-              context = generate_context(hashed_obj, hash.keys, options) if generate_context?(options)
+              context = generate_context(hashed_obj, hash.keys, options)
               hash.merge!(context)
             end
           end


### PR DESCRIPTION
We see that in the @context it is always the default vocabulary (http://data.bioontology.org/metadata/) that is used instead of the resolvable one. For example, the prefLabel context is "http://data.bioontology.org/metadata/skosprefLabel" where we should have "http://www.w3.org/2004/02/skos/core#prefLabel"

## The @conrext before 
![image](https://user-images.githubusercontent.com/29259906/168022363-be539511-797e-4075-8b0a-fa21ba167564.png)
## The @context after
![image](https://user-images.githubusercontent.com/29259906/168022412-7d3aa09d-35ae-4d2d-b799-abc0d5d8ea48.png)


