### PR TITLE
Feature: add the serialize_defaults to the attributes to load if set include = 'all'

### DIFF
--- a/lib/ontologies_linked_data/models/base.rb
+++ b/lib/ontologies_linked_data/models/base.rb
@@ -44,17 +44,17 @@ module LinkedData
         raise ArgumentError, "`attributes` should be an array" unless attributes.is_a?(Array)
 
         # Get attributes, either provided, all, or default
-        if !attributes.empty?
-          if attributes.first == :all
-            default_attrs = self.attributes
-          else
-            default_attrs = attributes
-          end
-        elsif self.hypermedia_settings[:serialize_default].empty?
-          default_attrs = self.attributes
-        else
-          default_attrs = self.hypermedia_settings[:serialize_default].dup
-        end
+        default_attrs = if !attributes.empty?
+                          if attributes.first == :all
+                            (self.attributes + self.hypermedia_settings[:serialize_default]).uniq
+                          else
+                            attributes
+                          end
+                        elsif self.hypermedia_settings[:serialize_default].empty?
+                          self.attributes
+                        else
+                          self.hypermedia_settings[:serialize_default].dup
+                        end
 
         embed_attrs = {}
         extra_attrs = []
@@ -101,7 +101,7 @@ module LinkedData
         # Add extra attrs to appropriate group (embed Hash vs default Array)
         extra_attrs.each do |attr|
           if attr.is_a?(Hash)
-            attr.each do |k,v|
+            attr.each do |k, v|
               if embed_attrs.key?(k)
                 embed_attrs[k].concat(v).uniq!
               else
@@ -149,7 +149,7 @@ module LinkedData
         if LinkedData.settings.enable_security
           user = nil
           options_hash = {}
-          args.each {|e| options_hash.merge!(e) if e.is_a?(Hash)}
+          args.each { |e| options_hash.merge!(e) if e.is_a?(Hash) }
           user = options_hash[:user]
 
           # Allow a passed option to short-cut the security process


### PR DESCRIPTION

In the ontology details endpoint (for example), if in the ontology model the "views" attribute is set as serialize_defaults it will force it to be shown even if it's an inverse property usually not shown.

But even with the serialize_defaults set, it will not be shown in the case if add the ?include=all to the request.

Fort example see https://github.com/ontoportal-lirmm/ontologies_api/issues/17

This feature fixes that.