### PR TITLE
Feature: add :ontologies to the serialize_default of the group model

### DIFF
--- a/lib/ontologies_linked_data/models/group.rb
+++ b/lib/ontologies_linked_data/models/group.rb
@@ -8,6 +8,7 @@ module LinkedData
       attribute :created, enforce: [:date_time], :default => lambda { |record| DateTime.now }
       attribute :ontologies, inverse: { on: :ontology, attribute: :group }
 
+      serialize_default :acronym, :name, :description, :created, :ontologies
       cache_timeout 86400
     end
   end


### PR DESCRIPTION
Fix this https://github.com/ontoportal-lirmm/ontologies_api/issues/12 to show the ontologies of an ontology