### PR TITLE
code coverage reporting with Codecov

### DIFF
--- a/.github/workflows/ruby-unit-tests.yml
+++ b/.github/workflows/ruby-unit-tests.yml
@@ -21,3 +21,9 @@ jobs:
     - name: Run unit tests
       # unit tests are run inside a container
       run: docker-compose run ${{ matrix.backend }} wait-for-it solr-ut:8983 -- bundle exec rake test TESTOPTS='-v'
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage/codecov-result.json
+        flags: unittests
+        fail_ci_if_error: false # optional (default = false)

--- a/.github/workflows/ruby-unit-tests.yml
+++ b/.github/workflows/ruby-unit-tests.yml
@@ -20,10 +20,13 @@ jobs:
       run: docker-compose --profile 4store build #profile flag is set in order to build all containers in this step
     - name: Run unit tests
       # unit tests are run inside a container
-      run: docker-compose run ${{ matrix.backend }} wait-for-it solr-ut:8983 -- bundle exec rake test TESTOPTS='-v'
+      # http://docs.codecov.io/docs/testing-with-docker
+      run: |
+        ci_env=`bash <(curl -s https://codecov.io/env)`
+        docker-compose run $ci_env -e CI --rm ${{ matrix.backend }} wait-for-it solr-ut:8983 -- bundle exec rake test TESTOPTS='-v'
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       with:
-        files: ./coverage/codecov-result.json
         flags: unittests
+        verbose: true
         fail_ci_if_error: false # optional (default = false)

--- a/.github/workflows/ruby-unit-tests.yml
+++ b/.github/workflows/ruby-unit-tests.yml
@@ -1,5 +1,8 @@
 name: Ruby Unit Tests
 
+env:
+  CODECOV: true
+
 on:
   push:
   pull_request:

--- a/.github/workflows/ruby-unit-tests.yml
+++ b/.github/workflows/ruby-unit-tests.yml
@@ -25,5 +25,6 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage/codecov-result.json
+        verbose: true
         flags: unittests
         fail_ci_if_error: false # optional (default = false)

--- a/.github/workflows/ruby-unit-tests.yml
+++ b/.github/workflows/ruby-unit-tests.yml
@@ -1,8 +1,5 @@
 name: Ruby Unit Tests
 
-env:
-  CODECOV: true
-
 on:
   push:
   pull_request:
@@ -28,6 +25,5 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage/codecov-result.json
-        verbose: true
         flags: unittests
         fail_ci_if_error: false # optional (default = false)

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'thin'
 
 # Testing
 group :test do
+  gem 'codecov', require: false # for CodeCove.io
   gem 'email_spec'
   gem 'minitest-reporters', '>= 0.5.0'
   gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -22,11 +22,11 @@ gem 'thin'
 
 # Testing
 group :test do
-  gem 'codecov', require: false # for CodeCove.io
   gem 'email_spec'
   gem 'minitest-reporters', '>= 0.5.0'
   gem 'pry'
   gem 'simplecov'
+  gem 'simplecov-cobertura' # for codecov.io
   gem 'test-unit-minitest'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
     ast (2.4.2)
     bcrypt (3.1.18)
     builder (3.2.4)
+    codecov (0.6.0)
+      simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     cube-ruby (0.0.3)
@@ -81,6 +83,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    json (2.6.2)
     json_pure (2.6.2)
     launchy (2.5.0)
       addressable (~> 2.7)
@@ -126,7 +129,7 @@ GEM
     rake (10.5.0)
     rdf (1.0.8)
       addressable (>= 2.2)
-    redis (4.6.0)
+    redis (4.7.1)
     regexp_parser (2.5.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -136,7 +139,8 @@ GEM
     rexml (3.2.5)
     rsolr (1.1.2)
       builder (>= 2.1.2)
-    rubocop (1.30.1)
+    rubocop (1.31.2)
+      json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -145,7 +149,7 @@ GEM
       rubocop-ast (>= 1.18.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.18.0)
+    rubocop-ast (1.19.1)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
@@ -168,7 +172,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unicode-display_width (2.1.0)
+    unicode-display_width (2.2.0)
     uuid (2.3.9)
       macaddr (~> 1.0)
 
@@ -180,6 +184,7 @@ DEPENDENCIES
   activesupport (~> 4)
   addressable (~> 2.8)
   bcrypt (~> 3.0)
+  codecov
   cube-ruby
   email_spec
   faraday (~> 1.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,8 +38,6 @@ GEM
     ast (2.4.2)
     bcrypt (3.1.18)
     builder (3.2.4)
-    codecov (0.6.0)
-      simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     cube-ruby (0.0.3)
@@ -158,6 +156,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     systemu (2.6.5)
@@ -184,7 +185,6 @@ DEPENDENCIES
   activesupport (~> 4)
   addressable (~> 2.8)
   bcrypt (~> 3.0)
-  codecov
   cube-ruby
   email_spec
   faraday (~> 1.9)
@@ -206,6 +206,7 @@ DEPENDENCIES
   rubocop
   rubyzip (~> 1.0)
   simplecov
+  simplecov-cobertura
   sparql-client!
   test-unit-minitest
   thin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,10 @@ x-app: &app
       # we are setting it to local app directory if we need to use 'bundle config local'
       BUNDLE_APP_CONFIG: /srv/ontoportal/ontologies_api/.bundle
       BUNDLE_PATH: /srv/ontoportal/bundle
-      COVERAGE: 'true'
+      COVERAGE: 'true' # enable simplecov code coverage
+      # pass CI env var to the container when it is set so that container knows it running in the CI pipeline
+      # specifically it will enable codecov when run by github actions
+      CI: ${CI:-'false'}
       REDIS_HOST: redis-ut
       REDIS_PORT: 6379
       SOLR_TERM_SEARCH_URL: http://solr-ut:8983/solr/term_search_core1

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -1,6 +1,15 @@
-# Start simplecov if this is a coverage task
-if ENV['COVERAGE'].eql?('true')
+# Start simplecov if this is a coverage task or if it is run in the CI workflows
+RUN_COVERAGE = ENV['COVERAGE'] || ENV['CODECOV'] || ENV['CI']
+if RUN_COVERAGE
   require 'simplecov'
+  if ENV['CODECOV'] == 'true'
+    require 'codecov'
+    # Generate HTML and JSON reports
+    SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+      SimpleCov::Formatter::HTMLFormatter,
+      SimpleCov::Formatter::Codecov # for CodeCov
+    ])
+  end
   SimpleCov.start do
     add_filter '/test/'
     add_filter 'app.rb'

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -1,15 +1,13 @@
-# Start simplecov if this is a coverage task or if it is run in the CI workflows
-RUN_COVERAGE = ENV['COVERAGE'] || ENV['CODECOV'] || ENV['CI']
-if RUN_COVERAGE
+# Start simplecov if this is a coverage task or if it is run in the CI pipeline
+if ENV['COVERAGE'] == 'true' || ENV['CI'] == 'true'
   require 'simplecov'
-  if ENV['CODECOV'] == 'true' || ENV['CI'] == 'true'
-    require 'codecov'
-    # Generate HTML and JSON reports
-    SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
-      SimpleCov::Formatter::HTMLFormatter,
-      SimpleCov::Formatter::Codecov # for CodeCov
-    ])
-  end
+  require 'simplecov-cobertura'
+  # https://github.com/codecov/ruby-standard-2
+  # Generate HTML and Cobertura reports which can be consumed by codecov uploader
+  SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::CoberturaFormatter
+  ])
   SimpleCov.start do
     add_filter '/test/'
     add_filter 'app.rb'

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -2,7 +2,7 @@
 RUN_COVERAGE = ENV['COVERAGE'] || ENV['CODECOV'] || ENV['CI']
 if RUN_COVERAGE
   require 'simplecov'
-  if ENV['CODECOV'] == 'true'
+  if ENV['CODECOV'] == 'true' || ENV['CI'] == 'true'
     require 'codecov'
     # Generate HTML and JSON reports
     SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([


### PR DESCRIPTION
This PR:
1. adds cobertura code coverage formatting for simplecove which makes it injectable by codecov.  
2. Adds github action step for uploading coverage reports to Codecov.io 