### PR TITLE
Refactor: extract replace rest_url_prefix to id_url_prefix and and vice versa methods

### DIFF
--- a/lib/ontologies_linked_data/models/base.rb
+++ b/lib/ontologies_linked_data/models/base.rb
@@ -27,12 +27,10 @@ module LinkedData
       # Override find method to make sure the id matches what is in the RDF store
       # Only do this if the setting is enabled, string comparison sucks
       def self.find(id, *options)
-        if LinkedData.settings.replace_url_prefix && id.to_s.start_with?(LinkedData.settings.rest_url_prefix)
-          id = RDF::IRI.new(id.to_s.sub(LinkedData.settings.rest_url_prefix, LinkedData.settings.id_url_prefix))
-        end
+        id = replace_url_prefix_to_id(id)
 
         # Handle `+` to ` ` conversion here because Sinatra doesn't do it for URI's
-        id = id.gsub("+", " ") unless id.start_with?("http")
+        id = id.gsub('+', ' ') unless id.start_with?('http')
 
         super(id, *options)
       end

--- a/lib/ontologies_linked_data/models/base.rb
+++ b/lib/ontologies_linked_data/models/base.rb
@@ -137,7 +137,32 @@ module LinkedData
         included_aggregates
       end
 
+      def self.replace_url_prefix_to_id(id)
+        if replace_url_prefix?(id)
+          id = RDF::IRI.new(id.to_s.sub(LinkedData.settings.rest_url_prefix, LinkedData.settings.id_url_prefix))
+        end
+        id
+      end
+
+      def self.replace_url_id_to_prefix(id)
+        if replace_url_id?(id)
+          id.to_s.gsub(LinkedData.settings.id_url_prefix, LinkedData.settings.rest_url_prefix)
+        else
+          id
+        end
+      end
+
+      def self.replace_url_prefix?(id)
+        LinkedData.settings.replace_url_prefix && id.to_s.start_with?(LinkedData.settings.rest_url_prefix)
+      end
+
+      def self.replace_url_id?(id)
+        LinkedData.settings.replace_url_prefix && id.to_s.start_with?(LinkedData.settings.id_url_prefix)
+      end
+
       private
+
+
 
       ##
       # Looks for an object 'owner' and looks in Thread.current[:remote_user]

--- a/lib/ontologies_linked_data/monkeypatches/object.rb
+++ b/lib/ontologies_linked_data/monkeypatches/object.rb
@@ -155,16 +155,10 @@ class Object
   ##
   # If the config option is set, turn http://data.bioontology.org urls into the configured REST url
   def convert_url_prefix(value)
-    if LinkedData.settings.replace_url_prefix
-      if value.is_a?(String) && value.start_with?(LinkedData.settings.id_url_prefix)
-        value = value.sub(LinkedData.settings.id_url_prefix, LinkedData.settings.rest_url_prefix)
-      end
-
-      if (value.is_a?(Array) || value.is_a?(Set)) && value.first.is_a?(String) && value.first.start_with?(LinkedData.settings.id_url_prefix)
-        value = value.map {|v| v.sub(LinkedData.settings.id_url_prefix, LinkedData.settings.rest_url_prefix)}
-      end
+    tmp = Array(value).map do |val|
+      LinkedData::Models::Base.replace_url_id_to_prefix(val)
     end
-    value
+    value.is_a?(Array) || value.is_a?(Set) ? tmp : tmp.first
   end
 
   ##

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -11,8 +11,8 @@ module LinkedData
 
           # Add the id to json-ld attribute
           if current_cls.ancestors.include?(LinkedData::Hypermedia::Resource) && !current_cls.embedded? && hashed_obj.respond_to?(:id)
-            prefixed_id = LinkedData.settings.replace_url_prefix ? hashed_obj.id.to_s.gsub(LinkedData.settings.id_url_prefix, LinkedData.settings.rest_url_prefix) : hashed_obj.id.to_s
-            hash["@id"] = prefixed_id
+            prefixed_id = LinkedData::Models::Base.replace_url_id_to_prefix(hashed_obj.id)
+            hash["@id"] = prefixed_id.to_s
           end
           # Add the type
           hash["@type"] = current_cls.type_uri.to_s if hash["@id"] && current_cls.respond_to?(:type_uri)

--- a/lib/ontologies_linked_data/serializers/xml.rb
+++ b/lib/ontologies_linked_data/serializers/xml.rb
@@ -9,8 +9,8 @@ module LinkedData
             current_cls = hashed_obj.respond_to?(:klass) ? hashed_obj.klass : hashed_obj.class
             # Add the id and type
             if current_cls.ancestors.include?(LinkedData::Hypermedia::Resource) && !current_cls.embedded?
-              prefixed_id = LinkedData.settings.replace_url_prefix ? hashed_obj.id.to_s.gsub(LinkedData.settings.id_url_prefix, LinkedData.settings.rest_url_prefix) : hashed_obj.id.to_s
-              hash["id"] = prefixed_id
+              prefixed_id = LinkedData::Models::Base.replace_url_id_to_prefix(hashed_obj.id)
+              hash["id"] = prefixed_id.to_s
               hash["type"] = current_cls.type_uri.to_s
             end
 


### PR DESCRIPTION
This RP is a small code refactoring, where I extracted the two methods: 

- `replace_url_prefix_to_id`: from **rest_url_prefix** to **id_url_prefix**, e.g http://stagedata.bioontology.org/ontologies/BRO would become http://data.bioontology.org/ontologies/BRO
- `replace_url_id_to_prefix`:  from **id_url_prefix** to **rest_url_prefix**, e.g http://data.bioontology.org/ontologies/BRO would become http://stagedata.bioontology.org/ontologies/BRO 

> **For information:** rest_url_prefix and id_url_prefix are defined in the configuration file and are used to separate the prefix URL to be shown in the JSON (rest_url_prefix) from the one that is stored in the triple store (id_url_prefix)

