### PR TITLE
Fix:  bug in the get_rest_mapping method

### DIFF
--- a/lib/ontologies_linked_data/mappings/mappings.rb
+++ b/lib/ontologies_linked_data/mappings/mappings.rb
@@ -437,7 +437,7 @@ eos
       graph_insert << [c.id, RDF::URI.new(rest_predicate), backup_mapping.id]
       Goo.sparql_update_client.insert_data(graph_insert, graph: sub.id)
     end
-    mapping = LinkedData::Models::Mapping.new(classes,"REST",process)
+    mapping = LinkedData::Models::Mapping.new(classes,"REST",process, backup_mapping.id)
     return mapping
   end
 

--- a/lib/ontologies_linked_data/mappings/mappings.rb
+++ b/lib/ontologies_linked_data/mappings/mappings.rb
@@ -380,7 +380,7 @@ WHERE {
   GRAPH ?s2 {
     ?c2 <#{rest_predicate}> ?uuid .
   }
-FILTER(?uuid = <#{mapping_id}>)
+FILTER(?uuid = <#{LinkedData::Models::Base.replace_url_prefix_to_id(mapping_id)}>)
 FILTER(?s1 != ?s2)
 } LIMIT 1
 eos

--- a/lib/ontologies_linked_data/models/base.rb
+++ b/lib/ontologies_linked_data/models/base.rb
@@ -27,12 +27,10 @@ module LinkedData
       # Override find method to make sure the id matches what is in the RDF store
       # Only do this if the setting is enabled, string comparison sucks
       def self.find(id, *options)
-        if LinkedData.settings.replace_url_prefix && id.to_s.start_with?(LinkedData.settings.rest_url_prefix)
-          id = RDF::IRI.new(id.to_s.sub(LinkedData.settings.rest_url_prefix, LinkedData.settings.id_url_prefix))
-        end
+        id = replace_url_prefix_to_id(id)
 
         # Handle `+` to ` ` conversion here because Sinatra doesn't do it for URI's
-        id = id.gsub("+", " ") unless id.start_with?("http")
+        id = id.gsub('+', ' ') unless id.start_with?('http')
 
         super(id, *options)
       end

--- a/lib/ontologies_linked_data/models/base.rb
+++ b/lib/ontologies_linked_data/models/base.rb
@@ -137,7 +137,32 @@ module LinkedData
         included_aggregates
       end
 
+      def self.replace_url_prefix_to_id(id)
+        if replace_url_prefix?(id)
+          id = RDF::IRI.new(id.to_s.sub(LinkedData.settings.rest_url_prefix, LinkedData.settings.id_url_prefix))
+        end
+        id
+      end
+
+      def self.replace_url_id_to_prefix(id)
+        if replace_url_id?(id)
+          id.to_s.gsub(LinkedData.settings.id_url_prefix, LinkedData.settings.rest_url_prefix)
+        else
+          id
+        end
+      end
+
+      def self.replace_url_prefix?(id)
+        LinkedData.settings.replace_url_prefix && id.to_s.start_with?(LinkedData.settings.rest_url_prefix)
+      end
+
+      def self.replace_url_id?(id)
+        LinkedData.settings.replace_url_prefix && id.to_s.start_with?(LinkedData.settings.id_url_prefix)
+      end
+
       private
+
+
 
       ##
       # Looks for an object 'owner' and looks in Thread.current[:remote_user]

--- a/lib/ontologies_linked_data/monkeypatches/object.rb
+++ b/lib/ontologies_linked_data/monkeypatches/object.rb
@@ -155,16 +155,10 @@ class Object
   ##
   # If the config option is set, turn http://data.bioontology.org urls into the configured REST url
   def convert_url_prefix(value)
-    if LinkedData.settings.replace_url_prefix
-      if value.is_a?(String) && value.start_with?(LinkedData.settings.id_url_prefix)
-        value = value.sub(LinkedData.settings.id_url_prefix, LinkedData.settings.rest_url_prefix)
-      end
-
-      if (value.is_a?(Array) || value.is_a?(Set)) && value.first.is_a?(String) && value.first.start_with?(LinkedData.settings.id_url_prefix)
-        value = value.map {|v| v.sub(LinkedData.settings.id_url_prefix, LinkedData.settings.rest_url_prefix)}
-      end
+    tmp = Array(value).map do |val|
+      LinkedData::Models::Base.replace_url_id_to_prefix(val)
     end
-    value
+    value.is_a?(Array) || value.is_a?(Set) ? tmp : tmp.first
   end
 
   ##

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -11,8 +11,8 @@ module LinkedData
 
           # Add the id to json-ld attribute
           if current_cls.ancestors.include?(LinkedData::Hypermedia::Resource) && !current_cls.embedded? && hashed_obj.respond_to?(:id)
-            prefixed_id = LinkedData.settings.replace_url_prefix ? hashed_obj.id.to_s.gsub(LinkedData.settings.id_url_prefix, LinkedData.settings.rest_url_prefix) : hashed_obj.id.to_s
-            hash["@id"] = prefixed_id
+            prefixed_id = LinkedData::Models::Base.replace_url_id_to_prefix(hashed_obj.id)
+            hash["@id"] = prefixed_id.to_s
           end
           # Add the type
           hash["@type"] = current_cls.type_uri.to_s if hash["@id"] && current_cls.respond_to?(:type_uri)

--- a/lib/ontologies_linked_data/serializers/xml.rb
+++ b/lib/ontologies_linked_data/serializers/xml.rb
@@ -9,8 +9,8 @@ module LinkedData
             current_cls = hashed_obj.respond_to?(:klass) ? hashed_obj.klass : hashed_obj.class
             # Add the id and type
             if current_cls.ancestors.include?(LinkedData::Hypermedia::Resource) && !current_cls.embedded?
-              prefixed_id = LinkedData.settings.replace_url_prefix ? hashed_obj.id.to_s.gsub(LinkedData.settings.id_url_prefix, LinkedData.settings.rest_url_prefix) : hashed_obj.id.to_s
-              hash["id"] = prefixed_id
+              prefixed_id = LinkedData::Models::Base.replace_url_id_to_prefix(hashed_obj.id)
+              hash["id"] = prefixed_id.to_s
               hash["type"] = current_cls.type_uri.to_s
             end
 

--- a/test/models/test_mappings.rb
+++ b/test/models/test_mappings.rb
@@ -288,6 +288,36 @@ class TestMapping < LinkedData::TestOntologyCommon
     end
     assert_equal 3, rest_mapping_count
   end
+
+  def test_get_rest_mapping
+    mapping_term_a, mapping_term_b, submissions_a, submissions_b, relations, user = rest_mapping_data
+
+    classes = get_mapping_classes(term_a:mapping_term_a[0], term_b: mapping_term_b[0],
+                                  submissions_a: submissions_a[0], submissions_b: submissions_b[0])
+
+    mappings_created = []
+    mappings_created << create_rest_mapping(relation: RDF::URI.new(relations[0]),
+                                            user: user,
+                                            classes: classes,
+                                            name: "proc#{0}")
+
+    assert_equal 1, mappings_created.size
+    created_mapping_id = mappings_created.first.id
+
+    refute_nil LinkedData::Mappings.get_rest_mapping(created_mapping_id)
+
+    old_replace = LinkedData.settings.replace_url_prefix
+    LinkedData.settings.replace_url_prefix = true
+
+    old_rest_url = LinkedData.settings.rest_url_prefix
+    LinkedData.settings.rest_url_prefix = 'data.test.org'
+
+    refute_nil LinkedData::Mappings.get_rest_mapping(LinkedData::Models::Base.replace_url_id_to_prefix(created_mapping_id))
+
+    LinkedData.settings.rest_url_prefix = old_rest_url
+    LinkedData.settings.replace_url_prefix = old_replace
+  end
+
   private
 
   def get_mapping_classes(term_a:, term_b:, submissions_a:, submissions_b:)


### PR DESCRIPTION
## Prerequisite
- https://github.com/ncbo/ontologies_linked_data/pull/155


## Issue

We have a bug in the [get_rest_mapping](https://github.com/ontoportal-lirmm/ontologies_linked_data/blob/master/lib/ontologies_linked_data/mappings/mappings.rb#L515) method when the **replace_url_prefix** is enabled. Where the mappings can't be found by their id.

## To reproduce 
 This PR comes with its [correspondent unit test](https://github.com/ncbo/ontologies_linked_data/compare/master...ontoportal-lirmm:pr%2Ffix%2Fget-rest-mapping-with-prefix-url?expand=1&title=Fix%20a%20bug%20in%20the%20get_rest_mapping%20method#diff-52e4ab4204215ddba0b2c976d01d18a26dac670a05048be1d07f77588f88eba9R292), that you can see to reproduce the bug.
 
