### PR TITLE
Feature: Get the correct type for skos concepts

### DIFF
--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -51,7 +51,7 @@ module LinkedData
           proc = hashed_obj
         end
 
-        collection = hashed_obj.collection
+        collection = hashed_obj.respond_to?(:collection) ? hashed_obj.collection : nil
         if collection
           proc.type_uri(collection).to_s
         else

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -16,7 +16,7 @@ module LinkedData
           end
 
           # Add the type
-          hash["@type"] = type(current_cls, hash, hashed_obj) if  hash["@id"]
+          hash["@type"] = type(current_cls, hashed_obj) if  hash["@id"]
 
           # Generate links
           # NOTE: If this logic changes, also change in xml.rb
@@ -42,7 +42,7 @@ module LinkedData
 
       private
 
-      def self.type(current_cls, hash, hashed_obj)
+      def self.type(current_cls, hashed_obj)
         if current_cls.respond_to?(:type_uri)
           # For internal class
           proc = current_cls

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -14,8 +14,9 @@ module LinkedData
             prefixed_id = LinkedData.settings.replace_url_prefix ? hashed_obj.id.to_s.gsub(LinkedData.settings.id_url_prefix, LinkedData.settings.rest_url_prefix) : hashed_obj.id.to_s
             hash["@id"] = prefixed_id
           end
+
           # Add the type
-          hash["@type"] = current_cls.type_uri.to_s if hash["@id"] && current_cls.respond_to?(:type_uri)
+          hash["@type"] = type(current_cls, hash, hashed_obj)
 
           # Generate links
           # NOTE: If this logic changes, also change in xml.rb
@@ -40,6 +41,23 @@ module LinkedData
       end
 
       private
+
+      def self.type(current_cls, hash, hashed_obj)
+        if hash["@id"] && current_cls.respond_to?(:type_uri)
+          # For internal class
+          proc = current_cls
+        elsif hash["@id"] && hashed_obj.respond_to?(:type_uri)
+          # For External and Interportal class
+          proc = hashed_obj
+        end
+
+        collection = hashed_obj.collection
+        if collection
+          proc.type_uri(collection).to_s
+        else
+          proc.type_uri.to_s
+        end
+      end
 
       def self.generate_context(object, serialized_attrs = [], options = {})
         return remove_unused_attrs(CONTEXTS[object.hash], serialized_attrs) unless CONTEXTS[object.hash].nil?

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -16,7 +16,7 @@ module LinkedData
           end
 
           # Add the type
-          hash["@type"] = type(current_cls, hash, hashed_obj)
+          hash["@type"] = type(current_cls, hash, hashed_obj) if  hash["@id"]
 
           # Generate links
           # NOTE: If this logic changes, also change in xml.rb
@@ -43,10 +43,10 @@ module LinkedData
       private
 
       def self.type(current_cls, hash, hashed_obj)
-        if hash["@id"] && current_cls.respond_to?(:type_uri)
+        if current_cls.respond_to?(:type_uri)
           # For internal class
           proc = current_cls
-        elsif hash["@id"] && hashed_obj.respond_to?(:type_uri)
+        elsif hashed_obj.respond_to?(:type_uri)
           # For External and Interportal class
           proc = hashed_obj
         end


### PR DESCRIPTION
### Issue

If we take as an example the [NLMVS ontology](https://data.bioontology.org/ontologies/NLMVS), which is  SKOS terminology with only SKOS Concepts (no OWL ontology)

But when we check one of its concepts like [Intraspinal abscess (disorder) ](https://data.bioontology.org/ontologies/NLMVS/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2F1427008), our API tell us that is of `@type: "owl:Class"` (see screenshot below)

<img width="1769" alt="image" src="https://user-images.githubusercontent.com/29259906/202477230-8c43f81b-e34c-4827-8193-c0bbc70804eb.png">


This PR fix that, by displaying the correct type, skos:Concept if SKOS and owl:Class if Ontology

### After

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/29259906/202477956-c00fa086-7c56-4d49-a5ee-539ac1b44463.png">

