### PR TITLE
Merge Develop to Master

### DIFF
--- a/.github/workflows/ruby-unit-tests.yml
+++ b/.github/workflows/ruby-unit-tests.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         verbose: true
         fail_ci_if_error: false # optional (default = false)

--- a/lib/ontologies_linked_data/models/submission_status.rb
+++ b/lib/ontologies_linked_data/models/submission_status.rb
@@ -31,7 +31,8 @@ module LinkedData
 
       USER_IGNORE = [
         "UPLOADED", "ERROR_UPLOADED",
-        "RDF_LABELS", "ERROR_RDF_LABELS"
+        "RDF_LABELS", "ERROR_RDF_LABELS",
+        "OBSOLETE", "ERROR_OBSOLETE",
       ]
 
       model :submission_status, name_with: :code


### PR DESCRIPTION
remove `obsolete` ontology submission status from email notifications