### PR TITLE
Require a list for the naturalLanguage attribute

### DIFF
--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -35,7 +35,7 @@ module LinkedData
       attribute :homepage
       attribute :publication
       attribute :uri, namespace: :omv
-      attribute :naturalLanguage, namespace: :omv
+      attribute :naturalLanguage, namespace: :omv, enforce: [:list]
       attribute :documentation, namespace: :omv
       attribute :version, namespace: :omv
       attribute :creationDate, namespace: :omv, enforce: [:date_time], default: lambda { |record| DateTime.now }


### PR DESCRIPTION
A minor change to enforce a list value for the naturalLanguage attribute, since ontology content can be written in multiple languages in the same ontology source file. This change is necessary to move forward on https://github.com/ncbo/bioportal-project/issues/304.