### PR TITLE
Proposed refactor: convert notification bodies to ERB templates

### DIFF
--- a/lib/ontologies_linked_data/utils/notifications.rb
+++ b/lib/ontologies_linked_data/utils/notifications.rb
@@ -106,28 +106,16 @@ module LinkedData
 
       def self.obofoundry_sync(missing_onts, obsolete_onts)
         ui_name = LinkedData.settings.ui_name
-        subject = "[#{ui_name}] OBO Foundry synchronization report"
-        body = ''
+        gem_path = Gem.loaded_specs['ontologies_linked_data'].full_gem_path
+        template = File.read(File.join(gem_path, 'views/emails/obofoundry_sync.erb'))
 
-        if missing_onts.size > 0
-          body << "<strong>The following OBO Library ontologies are missing from #{ui_name}:</strong><br/><br/>"
-          missing_onts.each do |ont|
-            body << "<a href='#{ont['homepage']}'>#{ont['id']}</a> (#{ont['title']})<br/><br/>"
-          end
-        end
+        b = binding
+        b.local_variable_set(:ui_name, ui_name)
+        b.local_variable_set(:missing_onts, missing_onts)
+        b.local_variable_set(:obsolete_onts, obsolete_onts)
+        body = ERB.new(template).result(b)
 
-        if obsolete_onts.size > 0
-          body << '<strong>The following OBO Library ontologies have been deprecated:</strong><br/><br/>'
-          obsolete_onts.each do |ont|
-            body << "<a href='#{ont['homepage']}'>#{ont['id']}</a> (#{ont['title']})<br/><br/>"
-          end
-        end
-
-        if body.empty?
-          body << "#{ui_name} and the OBO Foundry are in sync.<br/><br/>"
-        end
-
-        Notifier.notify_mails_separately subject, body, [LinkedData.settings.email_sender]
+        Notifier.notify_ontoportal_admins("[#{ui_name}] OBO Foundry synchronization report", body)
       end
 
       NEW_NOTE = <<EOS

--- a/views/emails/obofoundry_sync.erb
+++ b/views/emails/obofoundry_sync.erb
@@ -1,0 +1,17 @@
+<% if missing_onts.present? %>
+  <strong>The following OBO Foundry ontologies are missing from <%= ui_name %>:</strong><br /><br />
+  <% missing_onts.each do |ont| %>
+    <a href="<%= ont['homepage'] %>"><%= ont['id'] %></a> (<%= ont['title'] %>)<br /><br />
+  <% end %>
+<% end %>
+
+<% if obsolete_onts.present? %>
+  <strong>The following OBO Foundry ontologies have been deprecated:</strong><br /><br />
+  <% obsolete_onts.each do |ont| %>
+    <a href="<%= ont['homepage'] %>"><%= ont['id'] %></a> (<%= ont['title'] %>)<br /><br />
+  <% end %>
+<% end %>
+
+<% if missing_onts.blank? && obsolete_onts.blank? %>
+  <%= ui_name %> and the OBO Foundry are in sync.
+<% end %>


### PR DESCRIPTION
I recently had to figure out why the OBO Foundry [synchronization script was failing](https://github.com/ncbo/ncbo_cron/issues/78), along with the synchronization report that's supposed to go out via email at script completion. While looking at code in the [Notifications class](https://github.com/ncbo/ontologies_linked_data/blob/master/lib/ontologies_linked_data/utils/notifications.rb), I was bothered by the proliferation of heredocs and gsubbing. I propose using ERB templates to represent the notification bodies, and this pull request implements one example:

* Adds an ERB template to a top-level `views/emails` directory for the body of the OBO Foundry synchronization report
* Modifies the `obofoundry_sync` method to set the necessary variables and instantiate / complete the template