### PR TITLE
Feature: Multilingual Support - Add search and languages serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.bundle/
 *.swp
 *.gemtags
 .bundle

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem 'rest-client'
 gem 'rsolr'
 gem 'rubyzip', '~> 1.0'
 gem 'thin'
+gem 'request_store'
+
 
 # Testing
 group :test do
@@ -31,7 +33,6 @@ end
 group :development do
   gem 'rubocop', require: false
 end
-
 # NCBO gems (can be from a local dev path or from rubygems/git)
-gem 'goo', github: 'ncbo/goo', branch: 'master'
-gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'master'
+gem 'goo', github: 'ontoportal-lirmm/goo', branch: 'pr/sync-agroportal-bioportal'
+gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'develop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,17 @@
 GIT
-  remote: https://github.com/ncbo/goo.git
-  revision: ef2d816df2d263c905bd034efd449a964fa4890f
-  branch: master
+  remote: https://github.com/ncbo/sparql-client.git
+  revision: 1657f0dd69fd4b522d3549a6848670175f5e98cc
+  branch: develop
+  specs:
+    sparql-client (1.0.1)
+      json_pure (>= 1.4)
+      net-http-persistent (= 2.9.4)
+      rdf (>= 1.0)
+
+GIT
+  remote: https://github.com/ontoportal-lirmm/goo.git
+  revision: f2751fe9324e48a0a5c2a8b15580ab879fc53a2b
+  branch: pr/sync-agroportal-bioportal
   specs:
     goo (0.0.2)
       addressable (~> 2.8)
@@ -13,16 +23,6 @@ GIT
       rsolr
       sparql-client
       uuid
-
-GIT
-  remote: https://github.com/ncbo/sparql-client.git
-  revision: e89c26aa96f184dbe9b52d51e04fb3d9ba998dbc
-  branch: master
-  specs:
-    sparql-client (1.0.1)
-      json_pure (>= 1.4)
-      net-http-persistent (= 2.9.4)
-      rdf (>= 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -182,8 +182,7 @@ GEM
       macaddr (~> 1.0)
 
 PLATFORMS
-  arm64-darwin-22
-  x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   activesupport (~> 4)
@@ -204,6 +203,7 @@ DEPENDENCIES
   rack
   rack-test (~> 0.6)
   rake (~> 10.0)
+  request_store
   rest-client
   rsolr
   rubocop

--- a/config/solr/term_search/schema.xml
+++ b/config/solr/term_search/schema.xml
@@ -123,26 +123,46 @@
     <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
     <field name="_text_" type="text_general" indexed="true" stored="false" multiValued="true"/>
 
+
     <!-- NCBO specific fields -->
     <field name="resource_id"           type="string"             indexed="true"  stored="true"  multiValued="false" required="true" />
 
     <!-- searchable fields -->
-    <field name="prefLabel"             type="text_general"       indexed="true"  stored="true"  multiValued="false" />
-    <field name="prefLabelExact"        type="string_ci"          indexed="true"  stored="true"  multiValued="false" />
-    <field name="prefLabelSuggest"      type="text_suggest"       indexed="true"  stored="true"  omitNorms="true" />
-    <field name="prefLabelSuggestEdge"  type="text_suggest_edge"  indexed="true"  stored="true" />
-    <field name="prefLabelSuggestNgram" type="text_suggest_ngram" indexed="true"  stored="true"  omitNorms="true" />
+    <!-- all languages fields -->
+    <field name="prefLabel"             type="text_general"       indexed="true"  stored="true"  multiValued="true" />
+    <field name="prefLabelExact"        type="string_ci"          indexed="true"  stored="true"  multiValued="true" />
+    <field name="prefLabelSuggest"      type="text_suggest"       indexed="true"  stored="true"  multiValued="true"  omitNorms="true" />
+    <field name="prefLabelSuggestEdge"  type="text_suggest_edge"  indexed="true"  stored="true"  multiValued="true"  />
+    <field name="prefLabelSuggestNgram" type="text_suggest_ngram" indexed="true"  stored="true"  multiValued="true"  omitNorms="true" />
+
+    <!--  language specific fields  (e.g prefLabel_en or prefLabel_fr) -->
+    <dynamicField name="prefLabel_*" type="text_general" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="prefLabelExact_*" type="string_ci" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="prefLabelSuggest_*" type="text_suggest" indexed="true" stored="true" omitNorms="true" multiValued="true" />
+    <dynamicField name="prefLabelSuggestEdge_*" type="text_suggest_edge" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="prefLabelSuggestNgram_*" type="text_suggest_ngram" indexed="true" stored="true" omitNorms="true" multiValued="true" />
+
 
     <field name="synonym"               type="text_general"       indexed="true"  stored="true"  multiValued="true" />
     <field name="synonymExact"          type="string_ci"          indexed="true"  stored="true"  multiValued="true" />
     <field name="synonymSuggest"        type="text_suggest"       indexed="true"  stored="true"  omitNorms="true" multiValued="true" />
     <field name="synonymSuggestEdge"    type="text_suggest_edge"  indexed="true"  stored="true"  multiValued="true" />
     <field name="synonymSuggestNgram"   type="text_suggest_ngram" indexed="true"  stored="true"  omitNorms="true" multiValued="true" />
-    <field name="notation"              type="string_ci"          indexed="true"  stored="true"  multiValued="false" />
+
+    <dynamicField name="synonym_*" type="text_general" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="synonymExact_*" type="string_ci" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="synonymSuggest_*" type="text_suggest" indexed="true" stored="true" omitNorms="true" multiValued="true" />
+    <dynamicField name="synonymSuggestEdge_*" type="text_suggest_edge" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="synonymSuggestNgram_*" type="text_suggest_ngram" indexed="true" stored="true" omitNorms="true" multiValued="true" />
+
+
+    <field name="notation"              type="string_ci"       indexed="true"  stored="true"  multiValued="false" />
     <field name="oboId"                 type="string_ci"          indexed="true"  stored="true"  multiValued="false" />
     <field name="idAcronymMatch"        type="boolean"            indexed="true"  stored="true"  multiValued="false" default="false"/>
 
-    <field name="definition"            type="string"             indexed="true"  stored="true"  multiValued="true" />
+    <field name="definition" type="string" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="definition_*" type="string" indexed="true" stored="true" multiValued="true" />
+
     <field name="submissionAcronym"     type="string"             indexed="true"  stored="true"  multiValued="false" />
     <field name="parents"               type="string"             indexed="true"  stored="true"  multiValued="true" />
     <field name="ontologyType"          type="ontologyType"       indexed="true"  stored="true"  multiValued="false" />
@@ -251,9 +271,19 @@
     <copyField source="synonym" dest="synonymSuggestEdge" />
     <copyField source="synonym" dest="synonymSuggestNgram" />
 
+    <copyField source="prefLabel_*" dest="prefLabelExact_*" />
+    <copyField source="prefLabel_*" dest="prefLabelSuggest_*" />
+    <copyField source="prefLabel_*" dest="prefLabelSuggestEdge_*" />
+    <copyField source="prefLabel_*" dest="prefLabelSuggestNgram_*" />
+
+
+    <copyField source="synonym_*" dest="synonymExact_*" />
+    <copyField source="synonym_*" dest="synonymSuggest_*" />
+    <copyField source="synonym_*" dest="synonymSuggestEdge_*" />
+    <copyField source="synonym_*" dest="synonymSuggestNgram_*" />
+
     <copyField source="notation" dest="_text_"/>
     <copyField source="oboId"    dest="_text_"/>
-
 
     <!-- field type definitions. The "name" attribute is
        just a label to be used by field definitions.  The "class"
@@ -413,9 +443,9 @@
     <!-- A text field that only splits on whitespace for exact matching of words -->
     <dynamicField name="*_ws" type="text_ws"  indexed="true"  stored="true"/>
     <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- With this field type case is preserved for stored values, but a case insensitive field will
@@ -425,10 +455,10 @@
         order to match.
     -->
     <fieldType name="string_ci" class="solr.TextField" sortMissingLast="true" omitNorms="true">
-      <analyzer type="query">
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- A general text field that has reasonable, generic
@@ -438,21 +468,21 @@
 	       also applies synonyms.
 	  -->
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="true">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.FlattenGraphFilterFactory"/>
-        -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
+        <analyzer type="index">
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+            <!-- in this example, we will only use synonyms at query time
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+            -->
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- A text field with defaults appropriate for English: it
@@ -462,41 +492,41 @@
          also applies synonyms from synonyms.txt. -->
     <dynamicField name="*_txt_en" type="text_en"  indexed="true"  stored="true"/>
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.FlattenGraphFilterFactory"/>
-        -->
-        <!-- Case insensitive stop word removal.
-        -->
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="lang/stopwords_en.txt"
+        <analyzer type="index">
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <!-- in this example, we will only use synonyms at query time
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+            <filter class="solr.FlattenGraphFilterFactory"/>
+            -->
+            <!-- Case insensitive stop word removal.
+            -->
+            <filter class="solr.StopFilterFactory"
+                    ignoreCase="true"
+                    words="lang/stopwords_en.txt"
             />
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.EnglishPossessiveFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-	      -->
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="lang/stopwords_en.txt"
-        />
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.EnglishPossessiveFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-	      -->
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.EnglishPossessiveFilterFactory"/>
+            <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+            <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
+            <filter class="solr.EnglishMinimalStemFilterFactory"/>
+              -->
+            <filter class="solr.PorterStemFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.StopFilterFactory"
+                    ignoreCase="true"
+                    words="lang/stopwords_en.txt"
+            />
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.EnglishPossessiveFilterFactory"/>
+            <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+            <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
+            <filter class="solr.EnglishMinimalStemFilterFactory"/>
+              -->
+            <filter class="solr.PorterStemFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- A text field with defaults appropriate for English, plus
@@ -510,66 +540,66 @@
     -->
     <dynamicField name="*_txt_en_split" type="text_en_splitting"  indexed="true"  stored="true"/>
     <fieldType name="text_en_splitting" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
-      <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
-        <!-- Case insensitive stop word removal.
-        -->
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="lang/stopwords_en.txt"
-        />
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.PorterStemFilterFactory"/>
-        <filter class="solr.FlattenGraphFilterFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="lang/stopwords_en.txt"
-        />
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
+        <analyzer type="index">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <!-- in this example, we will only use synonyms at query time
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+            -->
+            <!-- Case insensitive stop word removal.
+            -->
+            <filter class="solr.StopFilterFactory"
+                    ignoreCase="true"
+                    words="lang/stopwords_en.txt"
+            />
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+            <filter class="solr.FlattenGraphFilterFactory" />
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.StopFilterFactory"
+                    ignoreCase="true"
+                    words="lang/stopwords_en.txt"
+            />
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+            <filter class="solr.PorterStemFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- Less flexible matching, but less false matches.  Probably not ideal for product names,
          but may be good for SKUs.  Can insert dashes in the wrong place and still match. -->
     <dynamicField name="*_txt_en_split_tight" type="text_en_splitting_tight"  indexed="true"  stored="true"/>
     <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
-      <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-        <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
-             possible with WordDelimiterGraphFilter in conjuncton with stemming. -->
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="solr.FlattenGraphFilterFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-        <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
-             possible with WordDelimiterGraphFilter in conjuncton with stemming. -->
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-      </analyzer>
+        <analyzer type="index">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+            <filter class="solr.EnglishMinimalStemFilterFactory"/>
+            <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
+                 possible with WordDelimiterGraphFilter in conjuncton with stemming. -->
+            <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+            <filter class="solr.FlattenGraphFilterFactory" />
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+            <filter class="solr.EnglishMinimalStemFilterFactory"/>
+            <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
+                 possible with WordDelimiterGraphFilter in conjuncton with stemming. -->
+            <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- Just like text_general except it reverses the characters of
@@ -577,76 +607,76 @@
     -->
     <dynamicField name="*_txt_rev" type="text_general_rev"  indexed="true"  stored="true"/>
     <fieldType name="text_general_rev" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
-                maxPosAsterisk="3" maxPosQuestion="2" maxFractionAsterisk="0.33"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
+        <analyzer type="index">
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
+                    maxPosAsterisk="3" maxPosQuestion="2" maxFractionAsterisk="0.33"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- text_suggest : Matches whole terms in the suggest text -->
     <fieldType name="text_suggest" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory"
-                generateWordParts="1"
-                generateNumberParts="1"
-                catenateWords="1"
-                catenateNumbers="1"
-                catenateAll="1"
-                splitOnCaseChange="1"
-                splitOnNumerics="1"
-                preserveOriginal="1"
-                />
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement=" " replace="all"/>
-      </analyzer>
-      <analyzer type="query">
-        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory"
-                generateWordParts="0"
-                generateNumberParts="0"
-                catenateWords="0"
-                catenateNumbers="0"
-                catenateAll="0"
-                splitOnCaseChange="0"
-                splitOnNumerics="0"
-                />
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement=" " replace="all"/>
-      </analyzer>
+        <analyzer type="index">
+            <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory"
+                    generateWordParts="1"
+                    generateNumberParts="1"
+                    catenateWords="1"
+                    catenateNumbers="1"
+                    catenateAll="1"
+                    splitOnCaseChange="1"
+                    splitOnNumerics="1"
+                    preserveOriginal="1"
+            />
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement=" " replace="all"/>
+        </analyzer>
+        <analyzer type="query">
+            <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory"
+                    generateWordParts="0"
+                    generateNumberParts="0"
+                    catenateWords="0"
+                    catenateNumbers="0"
+                    catenateAll="0"
+                    splitOnCaseChange="0"
+                    splitOnNumerics="0"
+            />
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement=" " replace="all"/>
+        </analyzer>
     </fieldType>
 
     <!-- text_suggest_edge : Will match from the left of the field, e.g. if the document field
      is "A brown fox" and the query is "A bro", it will match, but not "brown"
     -->
     <fieldType name="text_suggest_edge" class="solr.TextField">
-      <analyzer type="index">
-        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="([\.,;:-_])" replacement=" " replace="all"/>
-        <filter class="solr.EdgeNGramFilterFactory" maxGramSize="30" minGramSize="1"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement="" replace="all"/>
-      </analyzer>
-      <analyzer type="query">
-        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="([\.,;:-_])" replacement=" " replace="all"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement="" replace="all"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="^(.{30})(.*)?" replacement="$1" replace="all"/>
-      </analyzer>
+        <analyzer type="index">
+            <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.PatternReplaceFilterFactory" pattern="([\.,;:-_])" replacement=" " replace="all"/>
+            <filter class="solr.EdgeNGramFilterFactory" maxGramSize="30" minGramSize="1"/>
+            <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement="" replace="all"/>
+        </analyzer>
+        <analyzer type="query">
+            <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.PatternReplaceFilterFactory" pattern="([\.,;:-_])" replacement=" " replace="all"/>
+            <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement="" replace="all"/>
+            <filter class="solr.PatternReplaceFilterFactory" pattern="^(.{30})(.*)?" replacement="$1" replace="all"/>
+        </analyzer>
     </fieldType>
 
     <!-- text_suggest_ngram : Matches any word in the input field, with implicit right truncation.
@@ -654,39 +684,39 @@
      We use this to get partial matches, but these whould be boosted lower than exact and left-anchored
     -->
     <fieldType name="text_suggest_ngram" class="solr.TextField">
-      <analyzer type="index">
-        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.EdgeNGramFilterFactory" maxGramSize="20" minGramSize="1"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement="" replace="all"/>
-      </analyzer>
-      <analyzer type="query">
-        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement="" replace="all"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="^(.{20})(.*)?" replacement="$1" replace="all"/>
-      </analyzer>
+        <analyzer type="index">
+            <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.EdgeNGramFilterFactory" maxGramSize="20" minGramSize="1"/>
+            <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement="" replace="all"/>
+        </analyzer>
+        <analyzer type="query">
+            <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.PatternReplaceFilterFactory" pattern="([^\w\d\*æøåÆØÅ ])" replacement="" replace="all"/>
+            <filter class="solr.PatternReplaceFilterFactory" pattern="^(.{20})(.*)?" replacement="$1" replace="all"/>
+        </analyzer>
     </fieldType>
 
     <dynamicField name="*_phon_en" type="phonetic_en"  indexed="true"  stored="true"/>
     <fieldType name="phonetic_en" stored="false" indexed="true" class="solr.TextField" >
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.DoubleMetaphoneFilterFactory" inject="false"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.DoubleMetaphoneFilterFactory" inject="false"/>
+        </analyzer>
     </fieldType>
 
     <!-- lowercases the entire field value, keeping it as a single token.  -->
     <dynamicField name="*_s_lower" type="lowercase"  indexed="true"  stored="true"/>
     <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory" />
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory" />
+        </analyzer>
     </fieldType>
 
     <!--
@@ -695,12 +725,12 @@
     -->
     <dynamicField name="*_descendent_path" type="descendent_path"  indexed="true"  stored="true"/>
     <fieldType name="descendent_path" class="solr.TextField">
-      <analyzer type="index">
-        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.KeywordTokenizerFactory" />
-      </analyzer>
+        <analyzer type="index">
+            <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.KeywordTokenizerFactory" />
+        </analyzer>
     </fieldType>
 
     <!--
@@ -709,12 +739,12 @@
     -->
     <dynamicField name="*_ancestor_path" type="ancestor_path"  indexed="true"  stored="true"/>
     <fieldType name="ancestor_path" class="solr.TextField">
-      <analyzer type="index">
-        <tokenizer class="solr.KeywordTokenizerFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
-      </analyzer>
+        <analyzer type="index">
+            <tokenizer class="solr.KeywordTokenizerFactory" />
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
+        </analyzer>
     </fieldType>
 
     <!-- since fields of this type are by default not stored or indexed,
@@ -747,22 +777,22 @@
 
     <!-- Payloaded field types -->
     <fieldType name="delimited_payloads_float" stored="false" indexed="true" class="solr.TextField">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="float"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="float"/>
+        </analyzer>
     </fieldType>
     <fieldType name="delimited_payloads_int" stored="false" indexed="true" class="solr.TextField">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="integer"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="integer"/>
+        </analyzer>
     </fieldType>
     <fieldType name="delimited_payloads_string" stored="false" indexed="true" class="solr.TextField">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="identity"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="identity"/>
+        </analyzer>
     </fieldType>
 
     <!-- some examples for different languages (generally ordered by ISO code) -->
@@ -770,255 +800,255 @@
     <!-- Arabic -->
     <dynamicField name="*_txt_ar" type="text_ar"  indexed="true"  stored="true"/>
     <fieldType name="text_ar" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- for any non-arabic -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ar.txt" />
-        <!-- normalizes ﻯ to ﻱ, etc -->
-        <filter class="solr.ArabicNormalizationFilterFactory"/>
-        <filter class="solr.ArabicStemFilterFactory"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <!-- for any non-arabic -->
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ar.txt" />
+            <!-- normalizes ﻯ to ﻱ, etc -->
+            <filter class="solr.ArabicNormalizationFilterFactory"/>
+            <filter class="solr.ArabicStemFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- Bulgarian -->
     <dynamicField name="*_txt_bg" type="text_bg"  indexed="true"  stored="true"/>
     <fieldType name="text_bg" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_bg.txt" />
-        <filter class="solr.BulgarianStemFilterFactory"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_bg.txt" />
+            <filter class="solr.BulgarianStemFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- Catalan -->
     <dynamicField name="*_txt_ca" type="text_ca"  indexed="true"  stored="true"/>
     <fieldType name="text_ca" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes l', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ca.txt"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ca.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Catalan"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <!-- removes l', etc -->
+            <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ca.txt"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ca.txt" />
+            <filter class="solr.SnowballPorterFilterFactory" language="Catalan"/>
+        </analyzer>
     </fieldType>
 
     <!-- CJK bigram (see text_ja for a Japanese configuration using morphological analysis) -->
     <dynamicField name="*_txt_cjk" type="text_cjk"  indexed="true"  stored="true"/>
     <fieldType name="text_cjk" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- normalize width before bigram, as e.g. half-width dakuten combine  -->
-        <filter class="solr.CJKWidthFilterFactory"/>
-        <!-- for any non-CJK -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.CJKBigramFilterFactory"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <!-- normalize width before bigram, as e.g. half-width dakuten combine  -->
+            <filter class="solr.CJKWidthFilterFactory"/>
+            <!-- for any non-CJK -->
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.CJKBigramFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- Czech -->
     <dynamicField name="*_txt_cz" type="text_cz"  indexed="true"  stored="true"/>
     <fieldType name="text_cz" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_cz.txt" />
-        <filter class="solr.CzechStemFilterFactory"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_cz.txt" />
+            <filter class="solr.CzechStemFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- Danish -->
     <dynamicField name="*_txt_da" type="text_da"  indexed="true"  stored="true"/>
     <fieldType name="text_da" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Danish"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt" format="snowball" />
+            <filter class="solr.SnowballPorterFilterFactory" language="Danish"/>
+        </analyzer>
     </fieldType>
 
     <!-- German -->
     <dynamicField name="*_txt_de" type="text_de"  indexed="true"  stored="true"/>
     <fieldType name="text_de" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" />
-        <filter class="solr.GermanNormalizationFilterFactory"/>
-        <filter class="solr.GermanLightStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.GermanMinimalStemFilterFactory"/> -->
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="German2"/> -->
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" />
+            <filter class="solr.GermanNormalizationFilterFactory"/>
+            <filter class="solr.GermanLightStemFilterFactory"/>
+            <!-- less aggressive: <filter class="solr.GermanMinimalStemFilterFactory"/> -->
+            <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="German2"/> -->
+        </analyzer>
     </fieldType>
 
     <!-- Greek -->
     <dynamicField name="*_txt_el" type="text_el"  indexed="true"  stored="true"/>
     <fieldType name="text_el" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- greek specific lowercase for sigma -->
-        <filter class="solr.GreekLowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_el.txt" />
-        <filter class="solr.GreekStemFilterFactory"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <!-- greek specific lowercase for sigma -->
+            <filter class="solr.GreekLowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_el.txt" />
+            <filter class="solr.GreekStemFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- Spanish -->
     <dynamicField name="*_txt_es" type="text_es"  indexed="true"  stored="true"/>
     <fieldType name="text_es" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_es.txt" format="snowball" />
-        <filter class="solr.SpanishLightStemFilterFactory"/>
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Spanish"/> -->
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_es.txt" format="snowball" />
+            <filter class="solr.SpanishLightStemFilterFactory"/>
+            <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Spanish"/> -->
+        </analyzer>
     </fieldType>
 
     <!-- Basque -->
     <dynamicField name="*_txt_eu" type="text_eu"  indexed="true"  stored="true"/>
     <fieldType name="text_eu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_eu.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Basque"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_eu.txt" />
+            <filter class="solr.SnowballPorterFilterFactory" language="Basque"/>
+        </analyzer>
     </fieldType>
 
     <!-- Persian -->
     <dynamicField name="*_txt_fa" type="text_fa"  indexed="true"  stored="true"/>
     <fieldType name="text_fa" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <!-- for ZWNJ -->
-        <charFilter class="solr.PersianCharFilterFactory"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.ArabicNormalizationFilterFactory"/>
-        <filter class="solr.PersianNormalizationFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fa.txt" />
-      </analyzer>
+        <analyzer>
+            <!-- for ZWNJ -->
+            <charFilter class="solr.PersianCharFilterFactory"/>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.ArabicNormalizationFilterFactory"/>
+            <filter class="solr.PersianNormalizationFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fa.txt" />
+        </analyzer>
     </fieldType>
 
     <!-- Finnish -->
     <dynamicField name="*_txt_fi" type="text_fi"  indexed="true"  stored="true"/>
     <fieldType name="text_fi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fi.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Finnish"/>
-        <!-- less aggressive: <filter class="solr.FinnishLightStemFilterFactory"/> -->
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fi.txt" format="snowball" />
+            <filter class="solr.SnowballPorterFilterFactory" language="Finnish"/>
+            <!-- less aggressive: <filter class="solr.FinnishLightStemFilterFactory"/> -->
+        </analyzer>
     </fieldType>
 
     <!-- French -->
     <dynamicField name="*_txt_fr" type="text_fr"  indexed="true"  stored="true"/>
     <fieldType name="text_fr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes l', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" />
-        <filter class="solr.FrenchLightStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.FrenchMinimalStemFilterFactory"/> -->
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="French"/> -->
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <!-- removes l', etc -->
+            <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" />
+            <filter class="solr.FrenchLightStemFilterFactory"/>
+            <!-- less aggressive: <filter class="solr.FrenchMinimalStemFilterFactory"/> -->
+            <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="French"/> -->
+        </analyzer>
     </fieldType>
 
     <!-- Irish -->
     <dynamicField name="*_txt_ga" type="text_ga"  indexed="true"  stored="true"/>
     <fieldType name="text_ga" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes d', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ga.txt"/>
-        <!-- removes n-, etc. position increments is intentionally false! -->
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/hyphenations_ga.txt"/>
-        <filter class="solr.IrishLowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ga.txt"/>
-        <filter class="solr.SnowballPorterFilterFactory" language="Irish"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <!-- removes d', etc -->
+            <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ga.txt"/>
+            <!-- removes n-, etc. position increments is intentionally false! -->
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/hyphenations_ga.txt"/>
+            <filter class="solr.IrishLowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ga.txt"/>
+            <filter class="solr.SnowballPorterFilterFactory" language="Irish"/>
+        </analyzer>
     </fieldType>
 
     <!-- Galician -->
     <dynamicField name="*_txt_gl" type="text_gl"  indexed="true"  stored="true"/>
     <fieldType name="text_gl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_gl.txt" />
-        <filter class="solr.GalicianStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.GalicianMinimalStemFilterFactory"/> -->
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_gl.txt" />
+            <filter class="solr.GalicianStemFilterFactory"/>
+            <!-- less aggressive: <filter class="solr.GalicianMinimalStemFilterFactory"/> -->
+        </analyzer>
     </fieldType>
 
     <!-- Hindi -->
     <dynamicField name="*_txt_hi" type="text_hi"  indexed="true"  stored="true"/>
     <fieldType name="text_hi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <!-- normalizes unicode representation -->
-        <filter class="solr.IndicNormalizationFilterFactory"/>
-        <!-- normalizes variation in spelling -->
-        <filter class="solr.HindiNormalizationFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hi.txt" />
-        <filter class="solr.HindiStemFilterFactory"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <!-- normalizes unicode representation -->
+            <filter class="solr.IndicNormalizationFilterFactory"/>
+            <!-- normalizes variation in spelling -->
+            <filter class="solr.HindiNormalizationFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hi.txt" />
+            <filter class="solr.HindiStemFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- Hungarian -->
     <dynamicField name="*_txt_hu" type="text_hu"  indexed="true"  stored="true"/>
     <fieldType name="text_hu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hu.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Hungarian"/>
-        <!-- less aggressive: <filter class="solr.HungarianLightStemFilterFactory"/> -->
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hu.txt" format="snowball" />
+            <filter class="solr.SnowballPorterFilterFactory" language="Hungarian"/>
+            <!-- less aggressive: <filter class="solr.HungarianLightStemFilterFactory"/> -->
+        </analyzer>
     </fieldType>
 
     <!-- Armenian -->
     <dynamicField name="*_txt_hy" type="text_hy"  indexed="true"  stored="true"/>
     <fieldType name="text_hy" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hy.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Armenian"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hy.txt" />
+            <filter class="solr.SnowballPorterFilterFactory" language="Armenian"/>
+        </analyzer>
     </fieldType>
 
     <!-- Indonesian -->
     <dynamicField name="*_txt_id" type="text_id"  indexed="true"  stored="true"/>
     <fieldType name="text_id" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_id.txt" />
-        <!-- for a less aggressive approach (only inflectional suffixes), set stemDerivational to false -->
-        <filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_id.txt" />
+            <!-- for a less aggressive approach (only inflectional suffixes), set stemDerivational to false -->
+            <filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
+        </analyzer>
     </fieldType>
 
     <!-- Italian -->
-  <dynamicField name="*_txt_it" type="text_it"  indexed="true"  stored="true"/>
-  <fieldType name="text_it" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes l', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_it.txt"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_it.txt" format="snowball" />
-        <filter class="solr.ItalianLightStemFilterFactory"/>
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Italian"/> -->
-      </analyzer>
+    <dynamicField name="*_txt_it" type="text_it"  indexed="true"  stored="true"/>
+    <fieldType name="text_it" class="solr.TextField" positionIncrementGap="100">
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <!-- removes l', etc -->
+            <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_it.txt"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_it.txt" format="snowball" />
+            <filter class="solr.ItalianLightStemFilterFactory"/>
+            <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Italian"/> -->
+        </analyzer>
     </fieldType>
 
     <!-- Japanese using morphological analysis (see text_cjk for a configuration using bigramming)
@@ -1028,156 +1058,156 @@
     -->
     <dynamicField name="*_txt_ja" type="text_ja"  indexed="true"  stored="true"/>
     <fieldType name="text_ja" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="false">
-      <analyzer>
-        <!-- Kuromoji Japanese morphological analyzer/tokenizer (JapaneseTokenizer)
+        <analyzer>
+            <!-- Kuromoji Japanese morphological analyzer/tokenizer (JapaneseTokenizer)
 
-           Kuromoji has a search mode (default) that does segmentation useful for search.  A heuristic
-           is used to segment compounds into its parts and the compound itself is kept as synonym.
+               Kuromoji has a search mode (default) that does segmentation useful for search.  A heuristic
+               is used to segment compounds into its parts and the compound itself is kept as synonym.
 
-           Valid values for attribute mode are:
-              normal: regular segmentation
-              search: segmentation useful for search with synonyms compounds (default)
-            extended: same as search mode, but unigrams unknown words (experimental)
+               Valid values for attribute mode are:
+                  normal: regular segmentation
+                  search: segmentation useful for search with synonyms compounds (default)
+                extended: same as search mode, but unigrams unknown words (experimental)
 
-           For some applications it might be good to use search mode for indexing and normal mode for
-           queries to reduce recall and prevent parts of compounds from being matched and highlighted.
-           Use <analyzer type="index"> and <analyzer type="query"> for this and mode normal in query.
+               For some applications it might be good to use search mode for indexing and normal mode for
+               queries to reduce recall and prevent parts of compounds from being matched and highlighted.
+               Use <analyzer type="index"> and <analyzer type="query"> for this and mode normal in query.
 
-           Kuromoji also has a convenient user dictionary feature that allows overriding the statistical
-           model with your own entries for segmentation, part-of-speech tags and readings without a need
-           to specify weights.  Notice that user dictionaries have not been subject to extensive testing.
+               Kuromoji also has a convenient user dictionary feature that allows overriding the statistical
+               model with your own entries for segmentation, part-of-speech tags and readings without a need
+               to specify weights.  Notice that user dictionaries have not been subject to extensive testing.
 
-           User dictionary attributes are:
-                     userDictionary: user dictionary filename
-             userDictionaryEncoding: user dictionary encoding (default is UTF-8)
+               User dictionary attributes are:
+                         userDictionary: user dictionary filename
+                 userDictionaryEncoding: user dictionary encoding (default is UTF-8)
 
-           See lang/userdict_ja.txt for a sample user dictionary file.
+               See lang/userdict_ja.txt for a sample user dictionary file.
 
-           Punctuation characters are discarded by default.  Use discardPunctuation="false" to keep them.
+               Punctuation characters are discarded by default.  Use discardPunctuation="false" to keep them.
 
-           See http://wiki.apache.org/solr/JapaneseLanguageSupport for more on Japanese language support.
-        -->
-        <tokenizer class="solr.JapaneseTokenizerFactory" mode="search"/>
-        <!--<tokenizer class="solr.JapaneseTokenizerFactory" mode="search" userDictionary="lang/userdict_ja.txt"/>-->
-        <!-- Reduces inflected verbs and adjectives to their base/dictionary forms (辞書形) -->
-        <filter class="solr.JapaneseBaseFormFilterFactory"/>
-        <!-- Removes tokens with certain part-of-speech tags -->
-        <filter class="solr.JapanesePartOfSpeechStopFilterFactory" tags="lang/stoptags_ja.txt" />
-        <!-- Normalizes full-width romaji to half-width and half-width kana to full-width (Unicode NFKC subset) -->
-        <filter class="solr.CJKWidthFilterFactory"/>
-        <!-- Removes common tokens typically not useful for search, but have a negative effect on ranking -->
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ja.txt" />
-        <!-- Normalizes common katakana spelling variations by removing any last long sound character (U+30FC) -->
-        <filter class="solr.JapaneseKatakanaStemFilterFactory" minimumLength="4"/>
-        <!-- Lower-cases romaji characters -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
+               See http://wiki.apache.org/solr/JapaneseLanguageSupport for more on Japanese language support.
+            -->
+            <tokenizer class="solr.JapaneseTokenizerFactory" mode="search"/>
+            <!--<tokenizer class="solr.JapaneseTokenizerFactory" mode="search" userDictionary="lang/userdict_ja.txt"/>-->
+            <!-- Reduces inflected verbs and adjectives to their base/dictionary forms (辞書形) -->
+            <filter class="solr.JapaneseBaseFormFilterFactory"/>
+            <!-- Removes tokens with certain part-of-speech tags -->
+            <filter class="solr.JapanesePartOfSpeechStopFilterFactory" tags="lang/stoptags_ja.txt" />
+            <!-- Normalizes full-width romaji to half-width and half-width kana to full-width (Unicode NFKC subset) -->
+            <filter class="solr.CJKWidthFilterFactory"/>
+            <!-- Removes common tokens typically not useful for search, but have a negative effect on ranking -->
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ja.txt" />
+            <!-- Normalizes common katakana spelling variations by removing any last long sound character (U+30FC) -->
+            <filter class="solr.JapaneseKatakanaStemFilterFactory" minimumLength="4"/>
+            <!-- Lower-cases romaji characters -->
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- Latvian -->
     <dynamicField name="*_txt_lv" type="text_lv"  indexed="true"  stored="true"/>
     <fieldType name="text_lv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_lv.txt" />
-        <filter class="solr.LatvianStemFilterFactory"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_lv.txt" />
+            <filter class="solr.LatvianStemFilterFactory"/>
+        </analyzer>
     </fieldType>
 
     <!-- Dutch -->
     <dynamicField name="*_txt_nl" type="text_nl"  indexed="true"  stored="true"/>
     <fieldType name="text_nl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_nl.txt" format="snowball" />
-        <filter class="solr.StemmerOverrideFilterFactory" dictionary="lang/stemdict_nl.txt" ignoreCase="false"/>
-        <filter class="solr.SnowballPorterFilterFactory" language="Dutch"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_nl.txt" format="snowball" />
+            <filter class="solr.StemmerOverrideFilterFactory" dictionary="lang/stemdict_nl.txt" ignoreCase="false"/>
+            <filter class="solr.SnowballPorterFilterFactory" language="Dutch"/>
+        </analyzer>
     </fieldType>
 
     <!-- Norwegian -->
     <dynamicField name="*_txt_no" type="text_no"  indexed="true"  stored="true"/>
     <fieldType name="text_no" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_no.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Norwegian"/>
-        <!-- less aggressive: <filter class="solr.NorwegianLightStemFilterFactory"/> -->
-        <!-- singular/plural: <filter class="solr.NorwegianMinimalStemFilterFactory"/> -->
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_no.txt" format="snowball" />
+            <filter class="solr.SnowballPorterFilterFactory" language="Norwegian"/>
+            <!-- less aggressive: <filter class="solr.NorwegianLightStemFilterFactory"/> -->
+            <!-- singular/plural: <filter class="solr.NorwegianMinimalStemFilterFactory"/> -->
+        </analyzer>
     </fieldType>
 
     <!-- Portuguese -->
-  <dynamicField name="*_txt_pt" type="text_pt"  indexed="true"  stored="true"/>
-  <fieldType name="text_pt" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_pt.txt" format="snowball" />
-        <filter class="solr.PortugueseLightStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.PortugueseMinimalStemFilterFactory"/> -->
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Portuguese"/> -->
-        <!-- most aggressive: <filter class="solr.PortugueseStemFilterFactory"/> -->
-      </analyzer>
+    <dynamicField name="*_txt_pt" type="text_pt"  indexed="true"  stored="true"/>
+    <fieldType name="text_pt" class="solr.TextField" positionIncrementGap="100">
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_pt.txt" format="snowball" />
+            <filter class="solr.PortugueseLightStemFilterFactory"/>
+            <!-- less aggressive: <filter class="solr.PortugueseMinimalStemFilterFactory"/> -->
+            <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Portuguese"/> -->
+            <!-- most aggressive: <filter class="solr.PortugueseStemFilterFactory"/> -->
+        </analyzer>
     </fieldType>
 
     <!-- Romanian -->
     <dynamicField name="*_txt_ro" type="text_ro"  indexed="true"  stored="true"/>
     <fieldType name="text_ro" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ro.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Romanian"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ro.txt" />
+            <filter class="solr.SnowballPorterFilterFactory" language="Romanian"/>
+        </analyzer>
     </fieldType>
 
     <!-- Russian -->
     <dynamicField name="*_txt_ru" type="text_ru"  indexed="true"  stored="true"/>
     <fieldType name="text_ru" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ru.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Russian"/>
-        <!-- less aggressive: <filter class="solr.RussianLightStemFilterFactory"/> -->
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ru.txt" format="snowball" />
+            <filter class="solr.SnowballPorterFilterFactory" language="Russian"/>
+            <!-- less aggressive: <filter class="solr.RussianLightStemFilterFactory"/> -->
+        </analyzer>
     </fieldType>
 
     <!-- Swedish -->
     <dynamicField name="*_txt_sv" type="text_sv"  indexed="true"  stored="true"/>
     <fieldType name="text_sv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_sv.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Swedish"/>
-        <!-- less aggressive: <filter class="solr.SwedishLightStemFilterFactory"/> -->
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_sv.txt" format="snowball" />
+            <filter class="solr.SnowballPorterFilterFactory" language="Swedish"/>
+            <!-- less aggressive: <filter class="solr.SwedishLightStemFilterFactory"/> -->
+        </analyzer>
     </fieldType>
 
     <!-- Thai -->
     <dynamicField name="*_txt_th" type="text_th"  indexed="true"  stored="true"/>
     <fieldType name="text_th" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.ThaiTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_th.txt" />
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.ThaiTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_th.txt" />
+        </analyzer>
     </fieldType>
 
     <!-- Turkish -->
     <dynamicField name="*_txt_tr" type="text_tr"  indexed="true"  stored="true"/>
     <fieldType name="text_tr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.TurkishLowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_tr.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Turkish"/>
-      </analyzer>
+        <analyzer>
+            <tokenizer class="solr.StandardTokenizerFactory"/>
+            <filter class="solr.TurkishLowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_tr.txt" />
+            <filter class="solr.SnowballPorterFilterFactory" language="Turkish"/>
+        </analyzer>
     </fieldType>
 
     <!-- Similarity is the scoring routine for each document vs. a query.

--- a/lib/ontologies_linked_data/config/config.rb
+++ b/lib/ontologies_linked_data/config/config.rb
@@ -94,15 +94,13 @@ module LinkedData
     yield @settings, overide_connect_goo if block_given?
 
     # Check to make sure url prefix has trailing slash
-    @settings.rest_url_prefix = @settings.rest_url_prefix + '/' unless @settings.rest_url_prefix[-1].eql?('/')
+    @settings.rest_url_prefix = "#{@settings.rest_url_prefix}/" unless @settings.rest_url_prefix[-1].eql?('/')
 
     puts "(LD) >> Using rdf store #{@settings.goo_host}:#{@settings.goo_port}#{@settings.goo_path_query}"
     puts "(LD) >> Using term search server at #{@settings.search_server_url}"
     puts "(LD) >> Using property search server at #{@settings.property_search_server_url}"
-    puts '(LD) >> Using HTTP Redis instance at '+
-            "#{@settings.http_redis_host}:#{@settings.http_redis_port}"
-    puts '(LD) >> Using Goo Redis instance at '+
-            "#{@settings.goo_redis_host}:#{@settings.goo_redis_port}"
+    puts "(LD) >> Using HTTP Redis instance at #{@settings.http_redis_host}:#{@settings.http_redis_port}"
+    puts "(LD) >> Using Goo Redis instance at #{@settings.goo_redis_host}:#{@settings.goo_redis_port}"
 
     connect_goo unless overide_connect_goo
   end
@@ -132,15 +130,14 @@ module LinkedData
                                port: @settings.goo_redis_port)
 
         if @settings.enable_monitoring
-          puts "(LD) >> Enable SPARQL monitoring with cube #{@settings.cube_host}:"+
-                    "#{@settings.cube_port}"
+          puts "(LD) >> Enable SPARQL monitoring with cube #{@settings.cube_host}:#{@settings.cube_port}"
           conf.enable_cube do |opts|
             opts[:host] = @settings.cube_host
             opts[:port] = @settings.cube_port
           end
         end
       end
-    rescue Exception => e
+    rescue StandardError => e
       abort("EXITING: Cannot connect to triplestore and/or search server:\n  #{e}\n#{e.backtrace.join("\n")}")
     end
   end
@@ -153,23 +150,48 @@ module LinkedData
       conf.add_namespace(:omv, RDF::Vocabulary.new("http://omv.ontoware.org/2005/05/ontology#"))
       conf.add_namespace(:skos, RDF::Vocabulary.new("http://www.w3.org/2004/02/skos/core#"))
       conf.add_namespace(:owl, RDF::Vocabulary.new("http://www.w3.org/2002/07/owl#"))
+      conf.add_namespace(:rdf, RDF::Vocabulary.new("http://www.w3.org/1999/02/22-rdf-syntax-ns#"))
       conf.add_namespace(:rdfs, RDF::Vocabulary.new("http://www.w3.org/2000/01/rdf-schema#"))
-      conf.add_namespace(:metadata,
-                         RDF::Vocabulary.new("http://data.bioontology.org/metadata/"),
-                         default = true)
-      conf.add_namespace(:metadata_def,
-                         RDF::Vocabulary.new("http://data.bioontology.org/metadata/def/"))
+      conf.add_namespace(:metadata, RDF::Vocabulary.new("http://data.bioontology.org/metadata/"), default = true)
+      conf.add_namespace(:metadata_def, RDF::Vocabulary.new("http://data.bioontology.org/metadata/def/"))
       conf.add_namespace(:dc, RDF::Vocabulary.new("http://purl.org/dc/elements/1.1/"))
       conf.add_namespace(:xsd, RDF::Vocabulary.new("http://www.w3.org/2001/XMLSchema#"))
-      conf.add_namespace(:oboinowl_gen,
-                         RDF::Vocabulary.new("http://www.geneontology.org/formats/oboInOwl#"))
+      conf.add_namespace(:oboinowl_gen, RDF::Vocabulary.new("http://www.geneontology.org/formats/oboInOwl#"))
       conf.add_namespace(:obo_purl, RDF::Vocabulary.new("http://purl.obolibrary.org/obo/"))
-      conf.add_namespace(:umls,
-                         RDF::Vocabulary.new("http://bioportal.bioontology.org/ontologies/umls/"))
-      conf.id_prefix = "http://data.bioontology.org/"
+      conf.add_namespace(:umls, RDF::Vocabulary.new("http://bioportal.bioontology.org/ontologies/umls/"))
+      conf.add_namespace(:door, RDF::Vocabulary.new("http://kannel.open.ac.uk/ontology#"))
+      conf.add_namespace(:dct, RDF::Vocabulary.new("http://purl.org/dc/terms/"))
+
+      conf.add_namespace(:void, RDF::Vocabulary.new("http://rdfs.org/ns/void#"))
+      conf.add_namespace(:foaf, RDF::Vocabulary.new("http://xmlns.com/foaf/0.1/"))
+      conf.add_namespace(:vann, RDF::Vocabulary.new("http://purl.org/vocab/vann/"))
+      conf.add_namespace(:adms, RDF::Vocabulary.new("http://www.w3.org/ns/adms#"))
+      conf.add_namespace(:voaf, RDF::Vocabulary.new("http://purl.org/vocommons/voaf#"))
+      conf.add_namespace(:dcat, RDF::Vocabulary.new("http://www.w3.org/ns/dcat#"))
+      conf.add_namespace(:mod, RDF::Vocabulary.new("http://www.isibang.ac.in/ns/mod#"))
+      conf.add_namespace(:prov, RDF::Vocabulary.new("http://www.w3.org/ns/prov#"))
+      conf.add_namespace(:cc, RDF::Vocabulary.new("http://creativecommons.org/ns#"))
+      conf.add_namespace(:schema, RDF::Vocabulary.new("http://schema.org/"))
+      conf.add_namespace(:doap, RDF::Vocabulary.new("http://usefulinc.com/ns/doap#"))
+      conf.add_namespace(:bibo, RDF::Vocabulary.new("http://purl.org/ontology/bibo/"))
+      conf.add_namespace(:wdrs, RDF::Vocabulary.new("http://www.w3.org/2007/05/powder-s#"))
+      conf.add_namespace(:cito, RDF::Vocabulary.new("http://purl.org/spar/cito/"))
+      conf.add_namespace(:pav, RDF::Vocabulary.new("http://purl.org/pav/"))
+      conf.add_namespace(:oboInOwl, RDF::Vocabulary.new("http://www.geneontology.org/formats/oboInOwl#"))
+      conf.add_namespace(:idot, RDF::Vocabulary.new("http://identifiers.org/idot/"))
+      conf.add_namespace(:sd, RDF::Vocabulary.new("http://www.w3.org/ns/sparql-service-description#"))
+      conf.add_namespace(:org, RDF::Vocabulary.new("http://www.w3.org/ns/org#"))
+      conf.add_namespace(:cclicense, RDF::Vocabulary.new("http://creativecommons.org/licenses/"))
+      conf.add_namespace(:nkos, RDF::Vocabulary.new("http://w3id.org/nkos#"))
+      conf.add_namespace(:skosxl, RDF::Vocabulary.new("http://www.w3.org/2008/05/skos-xl#"))
+      conf.add_namespace(:dcterms, RDF::Vocabulary.new("http://purl.org/dc/terms/"))
+      conf.add_namespace(:uneskos, RDF::Vocabulary.new("http://purl.org/umu/uneskos#"))
+
+
+      conf.id_prefix = 'http://data.bioontology.org/'
       conf.pluralize_models(true)
     end
   end
-  self.goo_namespaces
+  goo_namespaces
 
 end

--- a/lib/ontologies_linked_data/models/base.rb
+++ b/lib/ontologies_linked_data/models/base.rb
@@ -42,17 +42,17 @@ module LinkedData
         raise ArgumentError, "`attributes` should be an array" unless attributes.is_a?(Array)
 
         # Get attributes, either provided, all, or default
-        if !attributes.empty?
-          if attributes.first == :all
-            default_attrs = self.attributes
-          else
-            default_attrs = attributes
-          end
-        elsif self.hypermedia_settings[:serialize_default].empty?
-          default_attrs = self.attributes
-        else
-          default_attrs = self.hypermedia_settings[:serialize_default].dup
-        end
+        default_attrs = if !attributes.empty?
+                          if attributes.first == :all
+                            (self.attributes + self.hypermedia_settings[:serialize_default]).uniq
+                          else
+                            attributes
+                          end
+                        elsif self.hypermedia_settings[:serialize_default].empty?
+                          self.attributes
+                        else
+                          self.hypermedia_settings[:serialize_default].dup
+                        end
 
         embed_attrs = {}
         extra_attrs = []

--- a/lib/ontologies_linked_data/models/class.rb
+++ b/lib/ontologies_linked_data/models/class.rb
@@ -50,33 +50,35 @@ module LinkedData
 
       attribute :parents, namespace: :rdfs,
                   property: lambda {|x| self.tree_view_property(x) },
-                  enforce: [:list, :class]
+                enforce: [:list, :class]
 
       #transitive parent
       attribute :ancestors, namespace: :rdfs,
-                  property: :subClassOf,
-                  enforce: [:list, :class],
-                  transitive: true
+                property: :subClassOf,
+                enforce: [:list, :class],
+                transitive: true
 
       attribute :children, namespace: :rdfs,
                   property: lambda {|x| self.tree_view_property(x) },
                   inverse: { on: :class , :attribute => :parents }
 
       attribute :subClassOf, namespace: :rdfs,
-                 enforce: [:list, :uri]
+                enforce: [:list, :uri]
 
       attribute :ancestors, namespace: :rdfs, property: :subClassOf, handler: :retrieve_ancestors
 
       attribute :descendants, namespace: :rdfs, property: :subClassOf,
-          handler: :retrieve_descendants
+                handler: :retrieve_descendants
 
       attribute :semanticType, enforce: [:list], :namespace => :umls, :property => :hasSTY
       attribute :cui, enforce: [:list], :namespace => :umls, alias: true
       attribute :xref, :namespace => :oboinowl_gen, alias: true,
-        :property => :hasDbXref
+                :property => :hasDbXref
 
       attribute :notes,
-            inverse: { on: :note, attribute: :relatedClass }
+                inverse: { on: :note, attribute: :relatedClass }
+      attribute :created, namespace:  :dcterms
+      attribute :modified, namespace:  :dcterms
 
       # Hypermedia settings
       embed :children, :ancestors, :descendants, :parents
@@ -135,6 +137,31 @@ module LinkedData
         "#{self.id.to_s}_#{self.submission.ontology.acronym}_#{self.submission.submissionId}"
       end
 
+      def to_hash(include_languages: false)
+        attr_hash = {}
+        self.class.attributes.each do |attr|
+          v = self.instance_variable_get("@#{attr}")
+          attr_hash[attr] = v unless v.nil?
+        end
+        properties_values = properties(include_languages: include_languages)
+        if properties_values
+          all_attr_uris = Set.new
+          self.class.attributes.each do |attr|
+            if self.class.collection_opts
+              all_attr_uris << self.class.attribute_uri(attr, self.collection)
+            else
+              all_attr_uris << self.class.attribute_uri(attr)
+            end
+          end
+          properties_values.each do |attr, values|
+            values = values.values.flatten if values.is_a?(Hash)
+            attr_hash[attr] = values.map { |v| v.to_s } unless all_attr_uris.include?(attr)
+          end
+        end
+        attr_hash[:id] = @id
+        attr_hash
+      end
+
       # to_set is an optional array that allows passing specific
       # field names that require updating
       # if to_set is nil, it's assumed to be a new document for insert
@@ -170,21 +197,30 @@ module LinkedData
           end
 
           acronym = self.submission.ontology.acronym
-          doc[:id] = class_id
+
           doc[:ontologyId] = self.submission.id.to_s
-          doc[:submissionAcronym] = acronym
+          doc[:submissionAcronym] = self.submission.ontology.acronym
           doc[:submissionId] = self.submission.submissionId
           doc[:ontologyType] = self.submission.ontology.ontologyType.get_code_from_id
           doc[:obsolete] = self.obsolete.to_s
 
           all_attrs = self.to_hash
-          std = [:prefLabel, :notation, :synonym, :definition, :cui]
-
+          std = [:id, :prefLabel, :notation, :synonym, :definition, :cui]
+          multi_language_fields = [:prefLabel, :synonym, :definition]
           std.each do |att|
             cur_val = all_attrs[att]
 
             # don't store empty values
             next if cur_val.nil? || (cur_val.respond_to?('empty?') && cur_val.empty?)
+
+            if cur_val.is_a?(Hash) # Multi language
+              if multi_language_fields.include?(att)
+                doc[att] = cur_val.values.flatten # index all values of each language
+                cur_val.each { |lang, values| doc["#{att}_#{lang}".to_sym] = values } # index values per language
+              else
+                doc[att] = cur_val.values.flatten.first
+              end
+            end
 
             if cur_val.is_a?(Array)
               # don't store empty values
@@ -192,7 +228,7 @@ module LinkedData
               doc[att] = []
               cur_val = cur_val.uniq
               cur_val.map { |val| doc[att] << (val.kind_of?(Goo::Base::Resource) ? val.id.to_s : val.to_s.strip) }
-            else
+            elsif doc[att].nil?
               doc[att] = cur_val.to_s.strip
             end
           end
@@ -206,7 +242,7 @@ module LinkedData
           # mdorf, 2/4/2024: special handling for :notation field because some ontologies have it defined as :prefixIRI
           if !doc[:notation] || doc[:notation].empty?
             if all_attrs[:prefixIRI] && !all_attrs[:prefixIRI].empty?
-              doc[:notation] = all_attrs[:prefixIRI].strip
+              doc[:notation] = all_attrs[:prefixIRI].values.flatten.first.strip
             else
               doc[:notation] = LinkedData::Utils::Triples::last_iri_fragment(doc[:id])
             end
@@ -260,28 +296,28 @@ module LinkedData
 
         self_props.each do |attr_key, attr_val|
           # unless doc.include?(attr_key)
-            if attr_val.is_a?(Array)
-              props[attr_key] = []
-              attr_val = attr_val.uniq
+          if attr_val.is_a?(Array)
+            props[attr_key] = []
+            attr_val = attr_val.uniq
 
-              attr_val.map { |val|
-                real_val = val.kind_of?(Goo::Base::Resource) ? val.id.to_s : val.to_s.strip
-
-                # don't store empty values
-                unless real_val.respond_to?('empty?') && real_val.empty?
-                  prop_vals << real_val
-                  props[attr_key] << real_val
-                end
-              }
-            else
-              real_val = attr_val.to_s.strip
+            attr_val.map { |val|
+              real_val = val.kind_of?(Goo::Base::Resource) ? val.id.to_s : val.to_s.strip
 
               # don't store empty values
               unless real_val.respond_to?('empty?') && real_val.empty?
                 prop_vals << real_val
-                props[attr_key] = real_val
+                props[attr_key] << real_val
               end
+            }
+          else
+            real_val = attr_val.to_s.strip
+
+            # don't store empty values
+            unless real_val.respond_to?('empty?') && real_val.empty?
+              prop_vals << real_val
+              props[attr_key] = real_val
             end
+          end
           # end
         end
 
@@ -309,9 +345,9 @@ module LinkedData
       BAD_PROPERTY_URIS = LinkedData::Mappings.mapping_predicates.values.flatten + ['http://bioportal.bioontology.org/metadata/def/prefLabel']
       EXCEPTION_URIS = ["http://bioportal.bioontology.org/ontologies/umls/cui"]
       BLACKLIST_URIS = BAD_PROPERTY_URIS - EXCEPTION_URIS
-      def properties
-        return nil if self.unmapped.nil?
-        properties = self.unmapped
+      def properties(*args)
+        return nil if self.unmapped(*args).nil?
+        properties = self.unmapped(*args)
         BLACKLIST_URIS.each {|bad_iri| properties.delete(RDF::URI.new(bad_iri))}
         properties
       end
@@ -499,7 +535,7 @@ module LinkedData
         return @intlHasChildren
      end
 
-     def load_has_children()
+      def load_has_children()
         if !instance_variable_get("@intlHasChildren").nil?
           return
         end
@@ -508,7 +544,7 @@ module LinkedData
         has_c = false
         Goo.sparql_query_client.query(query,
                       query_options: {rules: :NONE }, graphs: graphs)
-                          .each do |sol|
+           .each do |sol|
           has_c = true
         end
         @intlHasChildren = has_c
@@ -531,7 +567,7 @@ module LinkedData
               next_level_thread = Set.new
               query = hierarchy_query(direction,ids_slice)
               Goo.sparql_query_client.query(query,query_options: {rules: :NONE }, graphs: graphs)
-                  .each do |sol|
+                 .each do |sol|
                 parent = sol[:node].to_s
                 next if !parent.start_with?("http")
                 ontology = sol[:graph].to_s
@@ -570,7 +606,7 @@ GRAPH <#{submission_id}> {
 }
 LIMIT 1
 eos
-         return query
+        return query
       end
 
       def hierarchy_query(direction, class_ids)
@@ -591,7 +627,7 @@ GRAPH ?graph {
 FILTER (#{filter_ids})
 }
 eos
-         return query
+        return query
       end
 
       def append_if_not_there_already(path, r)

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -91,6 +91,13 @@ module LinkedData
         @mutex.synchronize(&block)
       end
 
+      def URI=(value)
+        self.uri  = value
+      end
+      def URI
+        self.uri
+      end
+
       def self.ontology_link(m)
         ontology_link = ""
 

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -15,7 +15,6 @@ module LinkedData
       include LinkedData::Concerns::SubmissionProcessable
       include LinkedData::Concerns::OntologySubmission::MetadataExtractor
 
-      FILES_TO_DELETE = ['labels.ttl', 'mappings.ttl', 'obsolete.ttl', 'owlapi.xrdf', 'errors.log']
       FLAT_ROOTS_LIMIT = 1000
 
       model :ontology_submission, name_with: lambda { |s| submission_id_generator(s) }

--- a/lib/ontologies_linked_data/monkeypatches/object.rb
+++ b/lib/ontologies_linked_data/monkeypatches/object.rb
@@ -54,7 +54,7 @@ class Object
     # Add methods
     methods = methods - do_not_serialize_nested(options)
     methods.each do |method|
-      hash[method] = self.send(method.to_s) if self.respond_to?(method) rescue next
+      populate_attribute(hash, method) if self.respond_to?(method) rescue next
     end
 
     # Get rid of everything except the 'only'
@@ -245,7 +245,7 @@ class Object
 
       attributes.each do |attribute|
         next unless self.respond_to?(attribute)
-        hash[attribute] = self.send(attribute)
+        populate_attribute(hash, attribute)
       end
     elsif !only.empty?
       # Only get stuff we need
@@ -257,13 +257,22 @@ class Object
     hash
   end
 
+  def populate_attribute(hash, attribute)
+    if self.method(attribute).parameters.eql?([[:rest, :args]])
+      hash[attribute] = self.send(attribute, include_languages: true)
+    else
+      # a serialized method
+      hash[attribute] = self.send(attribute)
+    end
+  end
+
   def populate_hash_from_list(hash, attributes)
     attributes.each do |attribute|
       attribute = attribute.to_sym
 
       next unless self.respond_to?(attribute)
       begin
-        hash[attribute] = self.send(attribute)
+        populate_attribute(hash, attribute)
       rescue Goo::Base::AttributeNotLoaded
         next
       rescue ArgumentError
@@ -338,6 +347,8 @@ class Object
   end
 
   def add_goo_values(goo_object, embedded_values, attributes_to_embed, options, &block)
+    return if goo_object.nil?
+
     if attributes_to_embed.length > 1
       embedded_values_hash = {}
       attributes_to_embed.each do |a|

--- a/lib/ontologies_linked_data/security/access_control.rb
+++ b/lib/ontologies_linked_data/security/access_control.rb
@@ -57,12 +57,12 @@ module LinkedData::Security
     def read_restricted_based_on?(based_on)
       if based_on.is_a?(Proc)
         instance_to_base_on = based_on.call(self)
-        restricted = instance_to_base_on.read_restricted?
+        restricted = instance_to_base_on ? instance_to_base_on.read_restricted?  : false
       elsif based_on.is_a?(LinkedData::Models::Base)
         restricted = based_on.read_restricted?
       elsif based_on.is_a?(Symbol)
         instance_to_base_on = based_on.send(based_on)
-        restricted = instance_to_base_on.read_restricted?
+        restricted =  instance_to_base_on ? instance_to_base_on.read_restricted?  : false
       else
         restricted = false
       end

--- a/lib/ontologies_linked_data/serializer.rb
+++ b/lib/ontologies_linked_data/serializer.rb
@@ -84,10 +84,15 @@ module LinkedData
     end
 
     def self.serialize(type, obj, params, request)
-      only = params["display"] || []
-      only = only.split(",") unless only.kind_of?(Array)
-      only, all = [], true if only[0].eql?("all")
-      options = {:only => only, :all => all, :params => params, :request => request}
+      
+      lang = self.get_language(params)
+
+      only = params['display'] || []
+      only = only.split(',') unless only.is_a?(Array)
+      all = only[0] == 'all'
+      only = all ? [] : only
+
+      options = { only: only, lang: lang, all: all, params: params, request: request } 
       LinkedData::Serializers.serialize(obj, type, options)
     end
 
@@ -101,6 +106,12 @@ module LinkedData
       else
         false
       end
+    end
+
+    def self.get_language(params)
+      lang = params['lang'] || params['language'] ||  Goo.main_languages&.first.to_s || 'en'
+      lang = lang.split(',').map {|l| l.downcase.to_sym}
+      return lang.length == 1 ? lang.first : lang
     end
 
   end

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -6,16 +6,20 @@ module LinkedData
       CONTEXTS = {}
 
       def self.serialize(obj, options = {})
+
+
         hash = obj.to_flex_hash(options) do |hash, hashed_obj|
           current_cls = hashed_obj.respond_to?(:klass) ? hashed_obj.klass : hashed_obj.class
+          result_lang = self.get_languages(get_object_submission(hashed_obj), options[:lang]) if result_lang.nil?
 
           # Add the id to json-ld attribute
           if current_cls.ancestors.include?(LinkedData::Hypermedia::Resource) && !current_cls.embedded? && hashed_obj.respond_to?(:id)
             prefixed_id = LinkedData::Models::Base.replace_url_id_to_prefix(hashed_obj.id)
             hash["@id"] = prefixed_id.to_s
           end
+
           # Add the type
-          hash["@type"] = current_cls.type_uri.to_s if hash["@id"] && current_cls.respond_to?(:type_uri)
+          hash["@type"] = type(current_cls, hashed_obj) if hash["@id"]
 
           # Generate links
           # NOTE: If this logic changes, also change in xml.rb
@@ -30,16 +34,56 @@ module LinkedData
           # Generate context
           if current_cls.ancestors.include?(Goo::Base::Resource) && !current_cls.embedded?
             if generate_context?(options)
-              context = generate_context(hashed_obj, hash.keys, options) if generate_context?(options)
+              context = generate_context(hashed_obj, hash.keys, options)
               hash.merge!(context)
             end
           end
+          hash['@context']['@language'] = result_lang if hash['@context']
         end
-
         MultiJson.dump(hash)
       end
 
       private
+
+      def self.get_object_submission(obj)
+        obj.class.respond_to?(:attributes) && obj.class.attributes.include?(:submission) ? obj.submission : nil
+      end
+
+      def self.get_languages(submission, user_languages)
+        result_lang = user_languages
+
+        if submission
+          submission.bring :naturalLanguage
+          languages = get_submission_languages(submission.naturalLanguage)
+          # intersection of the two arrays , if the requested language is not :all
+          result_lang = user_languages == :all ? languages : Array(user_languages) & languages
+          result_lang = result_lang.first if result_lang.length == 1
+        end
+
+        result_lang
+      end
+
+      def self.get_submission_languages(submission_natural_language = [])
+        submission_natural_language = submission_natural_language.values.flatten if submission_natural_language.is_a?(Hash)
+        submission_natural_language.map { |natural_language| natural_language.to_s['iso639'] && natural_language.to_s.split('/').last[0..1].to_sym }.compact
+      end 
+
+      def self.type(current_cls, hashed_obj)
+        if current_cls.respond_to?(:type_uri)
+          # For internal class
+          proc = current_cls
+        elsif hashed_obj.respond_to?(:type_uri)
+          # For External and Interportal class
+          proc = hashed_obj
+        end
+
+        collection = hashed_obj.respond_to?(:collection) ? hashed_obj.collection : nil
+        if collection
+          proc.type_uri(collection).to_s
+        else
+          proc.type_uri.to_s
+        end
+      end
 
       def self.generate_context(object, serialized_attrs = [], options = {})
         return remove_unused_attrs(CONTEXTS[object.hash], serialized_attrs) unless CONTEXTS[object.hash].nil?
@@ -52,17 +96,19 @@ module LinkedData
             linked_model = current_cls.model_settings[:range][attr]
           end
 
-          predicate = nil
           if linked_model && linked_model.ancestors.include?(Goo::Base::Resource) && !embedded?(object, attr)
             # linked object
-            predicate = {"@id" => linked_model.type_uri.to_s, "@type" => "@id"}
-          elsif current_cls.model_settings[:attributes][attr][:namespace]
+            predicate = { "@id" => linked_model.type_uri.to_s, "@type" => "@id" }
+          else
+            # use the original predicate property if set
+            predicate_attr = current_cls.model_settings[:attributes][attr][:property] || attr
             # predicate with custom namespace
-            predicate = "#{Goo.vocabulary[current_cls.model_settings[:attributes][attr][:namespace]].to_s}#{attr}"
+            # if the namespace can be resolved by the namespaces added in Goo then it will be resolved.
+            predicate = "#{Goo.vocabulary(current_cls.model_settings[:attributes][attr][:namespace])&.to_s}#{predicate_attr}"
           end
           hash[attr] = predicate unless predicate.nil?
         end
-        context = {"@context" => hash}
+        context = { "@context" => hash }
         CONTEXTS[object.hash] = context
         context = remove_unused_attrs(context, serialized_attrs) unless options[:params] && options[:params]["full_context"].eql?("true")
         context
@@ -75,12 +121,12 @@ module LinkedData
         links.each do |link|
           links_context[link.type] = link.type_uri.to_s
         end
-        return {"@context" => links_context}
+        return { "@context" => links_context }
       end
 
       def self.remove_unused_attrs(context, serialized_attrs = [])
-        new_context = context["@context"].reject {|k,v| !serialized_attrs.include?(k) && !k.to_s.start_with?("@")}
-        {"@context" => new_context}
+        new_context = context["@context"].reject { |k, v| !serialized_attrs.include?(k) && !k.to_s.start_with?("@") }
+        { "@context" => new_context }
       end
 
       def self.embedded?(object, attribute)
@@ -97,20 +143,19 @@ module LinkedData
         params = options[:params]
         params.nil? ||
           (params["no_context"].nil? ||
-                     !params["no_context"].eql?("true")) &&
-          (params["display_context"].nil? ||
-                    !params["display_context"].eql?("false"))
+            !params["no_context"].eql?("true")) &&
+            (params["display_context"].nil? ||
+              !params["display_context"].eql?("false"))
       end
 
       def self.generate_links?(options)
         params = options[:params]
         params.nil? ||
           (params["no_links"].nil? ||
-                     !params["no_links"].eql?("true")) &&
-          (params["display_links"].nil? ||
-                    !params["display_links"].eql?("false"))
+            !params["no_links"].eql?("true")) &&
+            (params["display_links"].nil? ||
+              !params["display_links"].eql?("false"))
       end
     end
   end
 end
-

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_archiver.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_archiver.rb
@@ -2,29 +2,49 @@ module LinkedData
   module Services
     class OntologySubmissionArchiver < OntologySubmissionProcess
 
-      FILES_TO_DELETE = %w[labels.ttl mappings.ttl obsolete.ttl owlapi.xrdf errors.log]
-
+      FILES_TO_DELETE = ['labels.ttl', 'mappings.ttl', 'obsolete.ttl', 'owlapi.xrdf', 'errors.log']
+      FOLDERS_TO_DELETE = ['unzipped']
+      FILE_SIZE_ZIPPING_THRESHOLD = 100 * 1024 * 1024 # 100MB
 
       def process
-        submission_archive
+        archive_submission
       end
 
       private
-      def submission_archive
+
+      def archive_submission
+        @submission.ontology.bring(:submissions)
+        submissions = @submission.ontology.submissions
+        return if submissions.nil?
+
+        submissions.each { |s| s.bring(:submissionId) }
+        submission = submissions.sort { |a, b| b.submissionId <=> a.submissionId }.first
+
+        return unless @submission.submissionId < submission.submissionId
+
         @submission.submissionStatus = nil
         status = LinkedData::Models::SubmissionStatus.find("ARCHIVED").first
         @submission.add_submission_status(status)
 
+        @submission.unindex
 
         # Delete everything except for original ontology file.
-        @submission.ontology.bring(:submissions)
-        submissions = @submission.ontology.submissions
-        unless submissions.nil?
-          submissions.each { |s| s.bring(:submissionId) }
-          submission = submissions.sort { |a, b| b.submissionId <=> a.submissionId }.first
-          # Don't perform deletion if this is the most recent submission.
-          delete_old_submission_files if @submission.submissionId < submission.submissionId
-        end
+        delete_old_submission_files
+        @submission.uploadFilePath = zip_submission_uploaded_file
+      end
+
+      def zip_submission_uploaded_file
+        @submission.bring(:uploadFilePath) if @submission.bring?(:uploadFilePath)
+        return @submission.uploadFilePath if @submission.zipped?
+
+        return @submission.uploadFilePath if @submission.uploadFilePath.nil? || @submission.uploadFilePath.empty?
+
+        return @submission.uploadFilePath if File.size(@submission.uploadFilePath) < FILE_SIZE_ZIPPING_THRESHOLD
+
+        old_path = @submission.uploadFilePath
+        zip_file = Utils::FileHelpers.zip_file(old_path)
+        FileUtils.rm(old_path, force: true)
+        zip_file
       end
 
       def delete_old_submission_files
@@ -33,10 +53,11 @@ module LinkedData
         submission_files.push(@submission.csv_path)
         submission_files.push(@submission.parsing_log_path) unless @submission.parsing_log_path.nil?
         FileUtils.rm(submission_files, force: true)
+        submission_folders = FOLDERS_TO_DELETE.map { |f| File.join(path_to_repo, f) }
+        submission_folders.each { |d| FileUtils.remove_dir(d) if File.directory?(d) }
       end
 
     end
-
 
   end
 end

--- a/lib/ontologies_linked_data/services/submission_process/submission_process.rb
+++ b/lib/ontologies_linked_data/services/submission_process/submission_process.rb
@@ -1,4 +1,4 @@
-module LinkedData
+  module LinkedData
   module Services
     class OntologySubmissionProcess
 
@@ -7,6 +7,10 @@ module LinkedData
       end
 
       def process(logger, options = {})
+        call
+      end
+
+      def call
         raise NotImplementedError
       end
     end

--- a/lib/ontologies_linked_data/utils/file.rb
+++ b/lib/ontologies_linked_data/utils/file.rb
@@ -7,6 +7,14 @@ require 'tmpdir'
 module LinkedData
   module Utils
     module FileHelpers
+      
+      class GzipFile
+        attr_accessor :name
+        def initialize(gz)
+          self.name = gz.orig_name
+        end
+      end
+
 
       def self.zip?(file_path)
         file_path = file_path.to_s
@@ -76,6 +84,21 @@ module LinkedData
           raise StandardError, "Unsupported file format: #{File.extname(file_path)}"
         end
         extracted_files
+      end
+
+      def self.zip_file(file_path)
+        return file_path if self.zip?(file_path)
+
+        zip_file_path = "#{file_path}.zip"
+        Zip::File.open(zip_file_path, Zip::File::CREATE) do |zipfile|
+          # Add the file to the zip
+          begin
+            zipfile.add(File.basename(file_path), file_path)
+          rescue Zip::EntryExistsError
+          end
+
+        end
+        zip_file_path
       end
 
       def self.automaster?(path, format)

--- a/lib/ontologies_linked_data/utils/triples.rb
+++ b/lib/ontologies_linked_data/utils/triples.rb
@@ -20,23 +20,26 @@ module LinkedData
         triples << triple(Goo.vocabulary(:rdfs)[:comment], subPropertyOf, Goo.vocabulary(:skos)[:definition])
 
 
+        # Add subPropertyOf triples for custom properties
         unless ont_sub.prefLabelProperty.nil?
-          unless ont_sub.prefLabelProperty == Goo.vocabulary(:rdfs)[:label]
-            triples << triple(ont_sub.prefLabelProperty, subPropertyOf, Goo.vocabulary(:metadata_def)[:prefLabel])
+          unless ont_sub.prefLabelProperty == Goo.vocabulary(:rdfs)[:label] || ont_sub.prefLabelProperty == Goo.vocabulary(:metadata_def)[:prefLabel]
+              triples << triple(ont_sub.prefLabelProperty, subPropertyOf, Goo.vocabulary(:metadata_def)[:prefLabel])
           end
         end
         unless ont_sub.definitionProperty.nil?
-          unless ont_sub.definitionProperty == Goo.vocabulary(:rdfs)[:label]
-            triples << triple(ont_sub.definitionProperty, subPropertyOf, Goo.vocabulary(:skos)[:definition])
+          unless ont_sub.definitionProperty == Goo.vocabulary(:rdfs)[:label] || ont_sub.definitionProperty == Goo.vocabulary(:skos)[:definition]
+              triples << triple(ont_sub.definitionProperty, subPropertyOf, Goo.vocabulary(:skos)[:definition])
           end
         end
         unless ont_sub.synonymProperty.nil?
-          unless ont_sub.synonymProperty == Goo.vocabulary(:rdfs)[:label]
+          unless ont_sub.synonymProperty == Goo.vocabulary(:rdfs)[:label] || ont_sub.synonymProperty == Goo.vocabulary(:skos)[:altLabel]
             triples << triple(ont_sub.synonymProperty, subPropertyOf, Goo.vocabulary(:skos)[:altLabel])
           end
         end
         unless ont_sub.authorProperty.nil?
-          triples << triple(ont_sub.authorProperty, subPropertyOf, Goo.vocabulary(:dc)[:creator])
+          unless ont_sub.authorProperty == Goo.vocabulary(:dc)[:creator]
+            triples << triple(ont_sub.authorProperty, subPropertyOf, Goo.vocabulary(:dc)[:creator])
+          end
         end
 
         if ont_sub.hasOntologyLanguage.obo? || ont_sub.hasOntologyLanguage.owl?

--- a/test/data/ontology_files/BRO_v3.5.owl
+++ b/test/data/ontology_files/BRO_v3.5.owl
@@ -616,6 +616,8 @@
 
     <owl:Class rdf:about="&activity;Activity">
         <core:prefLabel rdf:datatype="&xsd;string">Activity</core:prefLabel>
+        <core:prefLabel xml:lang="en">ActivityEnglish</core:prefLabel>
+        <core:prefLabel xml:lang="fr">Activité</core:prefLabel>
         <desc:definition rdf:datatype="&xsd;string">Activity of interest that may be related to a BRO:Resource.</desc:definition>
         <core:altLabel>activities</core:altLabel>
     </owl:Class>

--- a/test/data/ontology_files/agrooeMappings-05-05-2016.owl
+++ b/test/data/ontology_files/agrooeMappings-05-05-2016.owl
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:foaf="http://xmlns.com/foaf/0.1/"
+	xmlns:dbpedia="http://dbpedia.org/resource/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:dcterms="http://purl.org/dc/terms/"
+	xmlns:omv="http://omv.ontoware.org/2005/05/ontology#"
+	xmlns:door="http://kannel.open.ac.uk/ontology#"
+	xmlns:lexvo="http://lexvo.org/ontology#"
+	xmlns:void="http://rdfs.org/ns/void#"
+	xmlns:vann="http://purl.org/vocab/vann/"
+	xmlns:adms="http://www.w3.org/ns/adms#"
+	xmlns:voaf="http://purl.org/vocommons/voaf#"
+	xmlns:dcat="http://www.w3.org/ns/dcat#"
+	xmlns:prov="http://www.w3.org/ns/prov#"
+	xmlns:mod="http://www.isibang.ac.in/ns/mod#"
+	xmlns:cc="http://creativecommons.org/ns#"
+	xmlns:doap="http://usefulinc.com/ns/doap#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:schema="http://schema.org/">
+
+<!--Dans ce fichier, uniquement les 80 propriétés surlignées en jaune dans la synthetic presentation -->
+
+<!--DESCRIPTION OF THE ONTOLOGY AND ITS METADATA -->
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/ontology/agroportal_ontology_example.owl">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+	<rdf:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#Ontology"/>
+	
+	<!-- GENERAL DESCRIPTION -->
+	<omv:name xml:lang="en"> AgroPortal ontology example</omv:name>
+	<omv:name xml:lang="fr"> Exemple d'ontologie pour AgroPortal</omv:name>
+	<dcterms:alternative> AgroPortal example of ontology </dcterms:alternative>
+	<skos:altLabel>metadata example </skos:altLabel>
+	<omv:acronym> AGROOE</omv:acronym>
+	<omv:URI> http://lirmm.fr/ontology/agroportal_ontology_example.owl</omv:URI>
+	<dcterms:identifier>http://agroportal.lirmm.fr</dcterms:identifier>
+
+	<omv:description> AGROOE is an ontology used to test the metadata extraction</omv:description>
+	<dcterms:description> AGROOE is an ontology to illustrate how to describe their ontologies</dcterms:description>
+
+	<omv:documentation>http://agroportal.lirmm.fr</omv:documentation>
+	<rdfs:seeAlso>http://agroportal.lirmm.fr</rdfs:seeAlso>
+
+	<omv:keyClasses> List the labels of the most important classes in your ontology here </omv:keyClasses>
+	<foaf:primaryTopic> primary topic </foaf:primaryTopic>
+	<void:exampleResource>example resource</void:exampleResource>
+
+	<omv:notes> notes omv </omv:notes>
+	<adms:versionNotes>notes adms</adms:versionNotes>
+
+	<owl:deprecated rdf:datatype="xsd:boolean">false</owl:deprecated>
+	<skos:hiddenLabel>Ontology for metadata test</skos:hiddenLabel>
+	<dcterms:coverage rdf:resource="http://vocab.getty.edu/tgn/7009369"/>
+	<dcterms:abstract> An ontology to test automatic extraction of metadata </dcterms:abstract>
+
+	<foaf:depiction rdf:resource="http://lirmm.fr/2015/ontology/agrooeImage.png"/>
+	<doap:screenshots rdf:resource="http://lirmm.fr/2015/ontology/agrooeScreenshot.png"/>
+
+	<foaf:logo rdf:resource="http://lirmm.fr/2015/ontology/agrooeLogo.png"/>
+
+	<mod:competencyQuestion>competency question</mod:competencyQuestion>
+
+	<voaf:toDoList rdf:resource="http://lirmm.fr/2015/ontology/toDoList.txt"/>
+
+	<vann:preferredNamespaceUri>http://purl.org/vocab/vann/</vann:preferredNamespaceUri>
+	<void:uriSpace>name space URI (void)</void:uriSpace>
+
+	<vann:preferredNamespacePrefix>A preferred name space prefix</vann:preferredNamespacePrefix>
+	<cc:morePermissions> A related resource which describes additional permissions</cc:morePermissions>
+	<cc:useGuidelines> A related resource which defines non-binding use guidelines</cc:useGuidelines>
+
+	<omv:reference>http://agroportal.lirmm.fr</omv:reference>
+	<dcterms:bibliographicCitation>http://doi.org/dio-1</dcterms:bibliographicCitation>
+	<foaf:isPrimaryTopicOf>http://my-page-topic</foaf:isPrimaryTopicOf>
+
+	<foaf:homepage>http://agroportal.lirmm.fr</foaf:homepage>
+	<cc:attributionURL>http://agroportal.lirmm.fr</cc:attributionURL>
+	<doap:blog>http://agroportal.lirmm.fr</doap:blog>
+
+	<doap:repository>https://github.com/agroportal/agroportal_web_ui</doap:repository>
+	<doap:bug-database>https://github.com/agroportal/agroportal_web_ui</doap:bug-database>
+	<doap:mailing-list>Mailing list</doap:mailing-list>
+
+
+	<!-- NATURAL LANGUAGES IN WHICH LABELS ARE AVAILABLE-->
+	<omv:naturalLanguage rdf:resource="http://lexvo.org/id/iso639-3/eng"/>
+	<omv:naturalLanguage rdf:resource="http://lexvo.org/id/iso639-3/fra"/>
+		
+	<!-- DOMAIN DESCRIPTION -->
+	<omv:keywords> Ontology metadata, AgroPortal, BioPortal, ontology engineering </omv:keywords>
+	<omv:keywords> others keywords with omv </omv:keywords>
+	<dcat:keywords> others keywords with dcat </dcat:keywords>
+
+	<omv:hasDomain rdf:resource="http://dbpedia.org/resource/Ontology_engineering"/>
+	<omv:hasDomain rdf:resource="http://lirmm.fr/2015/resource/domain01"/>
+	<dcterms:subject>dcterms subject</dcterms:subject>
+	<dc:subject>dc subject</dc:subject>
+	<foaf:topic>foaf subject</foaf:topic>
+	<dcat:theme>dcat subject</dcat:theme>
+		
+	<!-- RELATED DATES -->
+	<!-- <omv:creationDate rdf:datatype="xsd:dateTime"> 2015-09-28 </omv:creationDate> -->
+	<dcterms:dateSubmitted rdf:datatype="xsd:dateTime">2015-09-28</dcterms:dateSubmitted>
+
+	<!-- <omv:modificationDate rdf:datatype="xsd:dateTime">2015-10-01</omv:modificationDate> -->
+	<dcterms:modified rdf:datatype="xsd:dateTime">2015-10-01</dcterms:modified>
+
+	<dcterms:valid rdf:datatype="xsd:dateTime">2015-10-10 ffffff</dcterms:valid>
+	<prov:invaliatedAtTime rdf:datatype="xsd:dateTime">2015-10-10 gggggg</prov:invaliatedAtTime>
+	<schema:endDate rdf:datatype="xsd:dateTime">2015-10-10 hhhhhh</schema:endDate>
+
+	<dcterms:created rdf:datatype="xsd:dateTime">2015-06-29</dcterms:created>
+	<dc:date>2015-06-29 nnnnnn</dc:date>
+	<dcterms:date>2015-06-29 mmmmmm</dcterms:date>
+	<prov:generatedAtTime>2015-06-29 oooooo</prov:generatedAtTime>
+	<mod:creationDate>2015-06-29 pppppp</mod:creationDate>
+	<doap:created>2015-06-29 qqqqqq</doap:created>
+
+	<!-- INTEGER -->
+	<omv:numberOfAxioms rdf:datatype="xsd:integer">78</omv:numberOfAxioms>
+	<void:triples rdf:datatype="xsd:integer">100</void:triples>
+	
+	<void:entities rdf:datatype="xsd:integer">123</void:entities>
+		
+	
+
+	<!-- CREDITS & METHODS -->
+	<omv:hasCreator rdf:resource="http://lirmm.fr/2015/resource/clement"/>
+	<dc:creator>Alfred DC</dc:creator>
+	<dcterms:creator>Gaston Dcterms</dcterms:creator>
+	<foaf:maker>Paul Foaf</foaf:maker>
+	<prov:wasAttributedTo>Mirabelle Prov</prov:wasAttributedTo>
+	<doap:maintainer>Huguette Doap</doap:maintainer>
+
+	<omv:hasContributor rdf:resource="http://lirmm.fr/2015/resource/vincent"/>
+	<omv:hasContributor rdf:resource="http://lirmm.fr/2015/resource/anne"/>
+	<dc:contributor>Benjamine Dessay</dc:contributor>
+	<dcterms:contributor>Léontine Dessaiterm</dcterms:contributor>
+	<doap:helper>Augustine Doap</doap:helper>
+
+	<dcterms:publisher rdf:resource="http://lirmm.fr/2015/resource/lirmm"/>
+	<dc:publisher>Éditions "La Science en Marche"</dc:publisher>
+	<adms:schemaAgency>Agence 007</adms:schemaAgency>
+
+	<omv:hasFormalityLevel rdf:resource="http://omv.ontoware.org/2005/05/ontology#Vocabulary"/>
+	<omv:hasOntologyLanguage rdf:resource="http://omv.ontoware.org/2005/05/ontology#OWL"/>
+	<omv:usedOntologyEngineeringMethodology rdf:resource="http://lirmm.fr/2015/resource/methodo01"/>
+
+	<omv:usedOntologyEngineeringTool rdf:resource="http://lirmm.fr/2015/resource/tool01"/>
+	<mod:methodologyUsed>A special methodology</mod:methodologyUsed>
+	<adms:representationTechnique>A technical representation</adms:representationTechnique>
+
+	<omv:conformsToKnowledgeRepresentationParadigm>Description Logics</omv:conformsToKnowledgeRepresentationParadigm>
+	<omv:hasOntologySyntax rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+	<dc:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+	<dcterms:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+	
+	<!-- ROLE & RATIONALE -->
+	<omv:knownUsage> This ontology is used by AgroPortal's developers to test the portal processing of ontology metadata. </omv:knownUsage>
+	<omv:designedForOntologyTask rdf:resource="http://lirmm.fr/2015/resource/task01"/>
+	<omv:designedForOntologyTask rdf:resource="http://lirmm.fr/2015/resource/task02"/>
+	<omv:endorsedBy rdf:resource="http://lirmm.fr/2015/resource/lirmm"/>
+	<omv:isOfType rdf:resource="http://omv.ontoware.org/2005/05/ontology#TaskOntology"/>
+	<dc:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#TaskOntology"/>
+	<dcterms:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#TaskOntology"/>
+	
+	<dcterms:audience> Audience </dcterms:audience>
+	<foaf:fundedBy rdf:resource="http://lirmm.fr/2015/resource/lirmm"/>
+	<mod:sponsoredBy rdf:resource="http://lirmm.fr/2015/resource/lirmm"/>
+
+
+	<!-- FORMAT & AVAILABILITY -->
+	<omv:resourceLocator> http://tubo.lirmm.fr/ncbo/agroportal_ontology_example.owl</omv:resourceLocator>
+	<doap:download-page> http://tubo.lirmm.fr/ncbo/agroportal_ontology_example.owl</doap:download-page>
+
+	<omv:status> development omv </omv:status>
+	<adms:status> development adms </adms:status>
+
+	<omv:version> alpha 0.2 </omv:version>
+	<doap:release> alpha 0.3 </doap:release>
+	<mod:version> alpha 0.4 </mod:version>
+	<owl:versionInfo>alpĥa 0.5</owl:versionInfo>
+
+	<omv:hasLicense rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
+	<dc:rights> DC rights </dc:rights>
+	<dcterms:rights> DCTERMS rights </dcterms:rights>
+	<dcterms:license> DCTERMS license </dcterms:license>
+	<dcterms:accessRight>Public</dcterms:accessRight>
+	<cc:license> DCTERMS license </cc:license>
+
+	<void:sparqlEndpoint> http://sparql.agroportal.lirmm.fr/ </void:sparqlEndpoint>
+
+	<void:dataDump> http://data.agroportal.lirmm.fr/ </void:dataDump>
+	<doap:download-mirror> http://data.agroportal.lirmm.fr/ </doap:download-mirror>
+
+	<void:uriLookupEndpoint> http://data.agroportal.lirmm.fr/ </void:uriLookupEndpoint>
+	<void:openSearchDescription> http://agroportal.lirmm.fr/ </void:openSearchDescription>
+	<doap:service-endpoint> http://agroportal.lirmm.fr/ </doap:service-endpoint>
+	<vann:example rdf:resource="http://lirmm.fr/2015/ontology/example.owl"/>
+
+	
+	<!--RELATION TO OTHER ONTOLOGIES -->
+	<omv:isIncompatibleWith rdf:resource="http://lirmm.fr/2015/ontology/test-ontology.owl"/>
+	<omv:hasPriorVersion rdf:resource="http://lirmm.fr/2015/ontology/agroportal_ontology_example_v0.1.owl"/>
+	<omv:isBackwardCompatibleWith rdf:resource="http://lirmm.fr/2015/ontology/agroportal_ontology_example_v0.1.owl"/>
+
+	<omv:useImports rdf:resource="http://lirmm.fr/2015/ontology/omv-import.owl"/>
+	<!--owl:imports rdf:resource="http://lirmm.fr/2015/ontology/owl-import.owl"/-->
+	<void:vocabulary rdf:resource="http://lirmm.fr/2015/ontology/void-import.owl"/>
+	<voaf:extends rdf:resource="http://lirmm.fr/2015/ontology/voaf-import.owl"/>
+	<dcterms:requires rdf:resource="http://lirmm.fr/2015/ontology/dcterms-import.owl"/>	
+
+	<dcterms:hasPart rdf:resource="http://lirmm.fr/2015/ontology/hasPart.owl"/>
+	<dcterms:isFormatOf rdf:resource="http://lirmm.fr/2015/ontology/isFormatOf.owl"/>
+	<dcterms:hasFormat rdf:resource="http://lirmm.fr/2015/ontology/hasFormat.owl"/>
+
+	<door:ontologyRelatedTo rdf:resource="http://lirmm.fr/2015/ontology/door-relation.owl"/>
+	<dc:relation rdf:resource="http://lirmm.fr/2015/ontology/dc-relation.owl"/>
+	<dcterms:relation rdf:resource="http://lirmm.fr/2015/ontology/dcterms-relation.owl"/>
+	<voaf:reliesOn rdf:resource="http://lirmm.fr/2015/ontology/voaf-relation.owl"/>
+
+
+	<door:similarTo rdf:resource="http://lirmm.fr/2015/ontology/door-similarTo.owl"/>
+	<voaf:similar rdf:resource="http://lirmm.fr/2015/ontology/voaf-similarTo.owl"/>
+
+	<door:isAlignedTo rdf:resource="http://lirmm.fr/2015/ontology/door-isAlignedTo.owl"/>
+	<voaf:hasEquivalencesWith rdf:resource="http://lirmm.fr/2015/ontology/voaf-equivalence.owl"/>
+
+	<door:explanationEvolution rdf:resource="http://lirmm.fr/2015/ontology/door-explanationEvolution.owl"/>
+	<voaf:specializes rdf:resource="http://lirmm.fr/2015/ontology/voaf-specializes.owl"/>
+	<prov:specializationOf rdf:resource="http://lirmm.fr/2015/ontology/prov-specializationOf.owl"/>
+
+	<door:hasDisparateModelling rdf:resource="http://lirmm.fr/2015/ontology/hasDisparateModelling.owl"/>
+	<door:comesFromTheSameDomain rdf:resource="http://lirmm.fr/2015/ontology/comesFromTheSameDomain.owl"/>
+	<voaf:usedBy rdf:resource="http://lirmm.fr/2015/ontology/usedBy.owl"/>
+
+	<voaf:metadataVoc rdf:resource="http://lirmm.fr/2015/ontology/voaf-metadataVoc.owl"/>
+	<mod:vocabularyUsed rdf:resource="http://lirmm.fr/2015/ontology/mod-vocabularyUsed.owl"/>
+	<adms:supportedSchema rdf:resource="http://lirmm.fr/2015/ontology/adms-supportedSchema.owl"/>
+
+
+	<voaf:generalizes rdf:resource="http://lirmm.fr/2015/ontology/generalizes.owl"/>
+	<voaf:hasDisjunctionsWith rdf:resource="http://lirmm.fr/2015/ontology/hasDisjunctionsWith.owl"/>
+	<adms:translation rdf:resource="http://lirmm.fr/2015/ontology/translation.owl"/>
+
+	<dcterms:source rdf:resource="http://lirmm.fr/2015/dcterms-source.owl"/>
+	<dc:source rdf:resource="http://lirmm.fr/2015/dc-source.owl"/>
+	<prov:wasInfluencedBy rdf:resource="http://lirmm.fr/2015/prov-wasInfluencedBy.owl"/>
+
+	<prov:wasGeneratedBy rdf:resource="http://lirmm.fr/2015/wasGeneratedBy.owl"/>
+	<prov:wasInvalidatedBy rdf:resource="http://lirmm.fr/2015/wasInvalidatedBy.owl"/>
+
+    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+</rdf:Description>
+
+<!-- DESCRIPTION OF RESOURCES INVOLVED IN METADATA DESCRIPTION -->
+
+<!-- DOMAINS-->
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/domain01">
+    <rdf:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#OntologyDomain"/>
+	<omv:name> BioPortal/AgroPortal Ontology engineering </omv:name>
+	<omv:URI> http://lirmm.fr/2015/resource/domain01 </omv:URI>
+</rdf:Description>
+
+<!-- ONTOLOGY TYPE-->
+<rdf:Description rdf:about="http://omv.ontoware.org/2005/05/ontology#TaskOntology">
+    <rdf:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#OntologyType"/>
+	<omv:name>Task Ontology !</omv:name>
+</rdf:Description>
+
+<!-- CREATOR & CONTRIBUTORS -->
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/clement">
+    <rdf:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#Person"/>
+	<rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+	<omv:firstName>Clement</omv:firstName>
+    <omv:lastName>Jonquet</omv:lastName>
+    <omv:eMail>jonquet@lirmm.fr</omv:eMail>
+	<foaf:openid> http://orcid.org/0000-0002-2404-1582 </foaf:openid>
+</rdf:Description>
+ 
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/vincent">
+    <rdf:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#Person"/>
+	<omv:firstName>Vincent</omv:firstName>
+    <omv:lastName>Emonet</omv:lastName>
+    <omv:eMail>vincent.emonet@lirmm.fr</omv:eMail>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/anne">
+    <rdf:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#Person"/>
+	<omv:firstName>Anne</omv:firstName>
+    <omv:lastName>Toulet</omv:lastName>
+    <omv:eMail>anne.toulet@lirmm.fr</omv:eMail>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/teest">
+    <rdf:type rdf:resource="http://purl.org/dc/terms/Agent"/>
+	<dc:title>test title</dc:title>
+    <rdfs:label>test label</rdfs:label>
+</rdf:Description>
+ 
+ <rdf:Description rdf:about="http://lirmm.fr/2015/resource/methodo01">
+    <rdf:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#OntologyEngineeringMethodology"/>
+	<omv:name> Manual </omv:name>
+	<omv:description> Done manually class by class with text editor </omv:description>
+</rdf:Description>
+ 
+ <rdf:Description rdf:about="http://lirmm.fr/2015/resource/tool01">
+    <rdf:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#OntologyEngineeringTool"/>
+	<omv:name> Notepad++ </omv:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/task01">
+    <rdf:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#OntologyTask"/>
+	<omv:name> Testing AgroPortal ontology metadata processing </omv:name>
+</rdf:Description>
+ 
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/task02">
+    <rdf:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#OntologyTask"/>
+	<omv:name> Illustrating ontology metadata </omv:name>
+	<omv:name> Illustrating ontology metadata 2 </omv:name>
+	<omv:name> Illustrating ontology metadata 3 </omv:name>
+	<omv:name> Illustrating ontology metadata 4 </omv:name>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/lirmm">
+    <rdf:type rdf:resource="http://omv.ontoware.org/2005/05/ontology#Organisation"/>
+	<omv:name xml:lang='eng'> Laboratory of Informatics, Robotics and Microelectronics of Montpellier </omv:name> 
+	<omv:name> LIRMM (default name) </omv:name>
+	<omv:name xml:lang='fr'> Laboratoire d'Informatique, de Robotique et de Microélectronique de Montpellier </omv:name>
+	<omv:acronym> LIRMM </omv:acronym>
+</rdf:Description>
+ 
+<!-- CONTENT OF THE ONTOLOGY -->
+ 
+<!-- PROPERTIES -->
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/AGROOE_p_01">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+    <rdfs:label xml:lang="en">is related to</rdfs:label>
+	<rdfs:label xml:lang="fr">est liée a </rdfs:label>
+	<rdfs:comment>'is related to' is the top level relation in AGROOE </rdfs:comment>
+    <dcterms:description xml:lang="en">A is related to B iff there is some relation between A and B.</dcterms:description>
+    <dcterms:identifier>AGROOE_p_01</dcterms:identifier>
+    <rdfs:isDefinedBy rdf:resource="http://lirmm.fr/2015/ontology/agroportal_ontology_example.owl"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/AGROOE_p_02">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:subPropertyOf rdf:resource="http://lirmm.fr/2015/resource/AGROOE_p_01"/>
+    <rdfs:label xml:lang="en">has attribute</rdfs:label>
+    <rdfs:label xml:lang="fr">a pour attibut</rdfs:label>
+    <dcterms:description xml:lang="en">has attribute is a relation that associates a entity with an attribute where an attribute is an intrinsic characteristic such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier) either directly or indirectly through generalization of entities of the same type.</dcterms:description>
+    <dcterms:identifier>AGROOE_p_02</dcterms:identifier>
+    <rdfs:isDefinedBy rdf:resource="http://lirmm.fr/2015/ontology/agroportal_ontology_example.owl"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/AGROOE_p_03">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:subPropertyOf rdf:resource="http://lirmm.fr/2015/resource/AGROOE_p_01"/>
+    <rdfs:inverseOf rdf:resource="http://lirmm.fr/2015/resource/AGROOE_p_02"/>
+    <rdfs:label xml:lang="en">is attribute of</rdfs:label>
+    <rdfs:label xml:lang="fr">est l'attribut de</rdfs:label>
+    <dcterms:description xml:lang="en">is attribute of is a relation that associates an attribute with an entity where an attribute is an intrinsic characteristic such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier) either directly or indirectly through generalization of entities of the same type.</dcterms:description>
+    <dcterms:identifier>AGROOE_p_03</dcterms:identifier>
+    <rdfs:isDefinedBy rdf:resource="http://lirmm.fr/2015/ontology/agroportal_ontology_example.owl"/>
+</rdf:Description>
+
+ <!-- CLASSES -->
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/AGROOE_c_01">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">entity</rdfs:label>
+    <rdfs:label xml:lang="fr">entité</rdfs:label>
+    <dcterms:description>Every thing is an entity.</dcterms:description>
+    <dcterms:identifier>AGROOE_c_01</dcterms:identifier>
+    <rdfs:isDefinedBy rdf:resource="http://lirmm.fr/2015/ontology/agroportal_ontology_example.owl"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/AGROOE_c_02">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:subClassOf rdf:resource="http://lirmm.fr/2015/resource/AGROOE_c_01"/>
+    <rdfs:label xml:lang="en">material entity</rdfs:label>
+    <rdfs:label xml:lang="fr">entité matérielle</rdfs:label>
+    <dcterms:description xml:lang="en">Some entities are material.</dcterms:description>
+    <dcterms:identifier>AGROOE_c_02</dcterms:identifier>
+    <rdfs:isDefinedBy rdf:resource="http://lirmm.fr/2015/ontology/agroportal_ontology_example.owl"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/AGROOE_c_03">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:subClassOf rdf:resource="http://lirmm.fr/2015/resource/AGROOE_c_02"/>
+    <rdfs:label xml:lang="en">material detailed entity</rdfs:label>
+    <rdfs:label xml:lang="fr">entité matérielle detaillée</rdfs:label>
+    <skos:prefLabel xml:lang="en">skos prefLabel en</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">skos prefLabel fr</skos:prefLabel>
+    <skos:prefLabel>skos prefLabel rien</skos:prefLabel>
+    <skos:altLabel xml:lang="en">entity eng</skos:altLabel>
+    <skos:altLabel xml:lang="fr">entité fra</skos:altLabel>
+    <skos:altLabel xml:lang="es">entita esp</skos:altLabel>
+    <skos:altLabel>entite rien</skos:altLabel>
+    <dcterms:description xml:lang="en">Some entities are material and detailed.</dcterms:description>
+    <rdfs:comment xml:lang="en">Some entities are material and detailed.</rdfs:comment>
+    <rdfs:comment xml:lang="fr">comment fr</rdfs:comment>
+    <rdfs:comment xml:lang="es">comment es.</rdfs:comment>
+    <rdfs:comment>comment rien</rdfs:comment>
+    <dcterms:identifier>AGROOE_c_03</dcterms:identifier>
+    <rdfs:isDefinedBy rdf:resource="http://lirmm.fr/2015/ontology/agroportal_ontology_example.owl"/>
+</rdf:Description>
+    
+ <!-- INSTANCES -->
+ 
+ <rdf:Description rdf:about="http://lirmm.fr/2015/resource/AGROOE_i_01">
+    <rdf:type rdf:resource="http://lirmm.fr/2015/resource/AGROOE_c_01"/>
+    <rdfs:label xml:lang="en">human beings</rdfs:label>
+    <rdfs:label xml:lang="fr">les êtres humain</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://lirmm.fr/2015/ontology/agroportal_ontology_example.owl"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://lirmm.fr/2015/resource/AGROOE_i_02">
+    <rdf:type rdf:resource="http://lirmm.fr/2015/resource/AGROOE_c_01"/>
+    <rdfs:label xml:lang="en">aliens</rdfs:label>
+    <rdfs:label xml:lang="fr">les étrangers</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://lirmm.fr/2015/ontology/agroportal_ontology_example.owl"/>
+</rdf:Description>
+ 
+ </rdf:RDF>

--- a/test/models/notes/test_note.rb
+++ b/test/models/notes/test_note.rb
@@ -19,9 +19,11 @@ class TestNote < LinkedData::TestCase
   end
 
   def _ontology_and_class
-    count, acronyms, ontologies = create_ontologies_and_submissions(ont_count: 1, submission_count: 1, process_submission: true)
+    count, acronyms, ontologies = create_ontologies_and_submissions(ont_count: 1, submission_count: 1,
+                                                                    process_submission: true,
+                                                                    process_options: {process_rdf: true, extract_metadata: false})
     ontology = ontologies.first
-    cls = LinkedData::Models::Class.where.include(:prefLabel).in(ontology.latest_submission).read_only.page(1, 1).first
+    cls = LinkedData::Models::Class.where.include(:prefLabel).in(ontology.latest_submission).read_only.first
     return ontology, cls
   end
 

--- a/test/models/test_class_portal_lang.rb
+++ b/test/models/test_class_portal_lang.rb
@@ -1,0 +1,105 @@
+require_relative './test_ontology_common'
+class TestClassPortalLang < LinkedData::TestOntologyCommon
+
+  def self.before_suite
+    @@old_main_languages = Goo.main_languages
+    RequestStore.store[:requested_lang] = nil
+    parse
+  end
+
+  def self.after_suite
+    Goo.main_languages = @@old_main_languages
+    RequestStore.store[:requested_lang] = nil
+  end
+
+  def self.parse
+    new('').submission_parse('AGROOE', 'AGROOE Test extract metadata ontology',
+                              './test/data/ontology_files/agrooeMappings-05-05-2016.owl', 1,
+                              process_rdf: true, index_search: false,
+                              run_metrics: false, reasoning: true)
+  end
+
+  def test_map_attribute_found
+    cls = parse_and_get_class lang: [:FR]
+    cls.bring :unmapped
+    LinkedData::Models::Class.map_attributes(cls)
+    assert_equal ['entité matérielle detaillée'], cls.label
+    assert_includes ['skos prefLabel fr', 'skos prefLabel rien'], cls.prefLabel
+    assert_equal ['entité fra', 'entite rien'].sort, cls.synonym.sort
+  end
+
+  def test_map_attribute_not_found
+    cls = parse_and_get_class lang: [:ES]
+    cls.bring :unmapped
+    LinkedData::Models::Class.map_attributes(cls)
+    assert_empty cls.label
+    assert_equal 'skos prefLabel rien', cls.prefLabel
+    assert_equal ['entita esp', 'entite rien'].sort, cls.synonym.sort
+  end
+
+  def test_map_attribute_secondary_lang
+    cls = parse_and_get_class lang: %i[ES FR]
+    cls.bring :unmapped
+    LinkedData::Models::Class.map_attributes(cls)
+    assert_empty cls.label
+    assert_equal 'skos prefLabel rien', cls.prefLabel
+    assert_equal ['entita esp', 'entite rien'].sort, cls.synonym.sort
+  end
+
+
+  def test_label_main_lang_fr_found
+    cls = parse_and_get_class lang: [:FR]
+    assert_equal ['entité matérielle detaillée'], cls.label
+    assert_includes ['skos prefLabel fr', 'skos prefLabel rien'], cls.prefLabel
+    assert_equal ['entité fra', 'entite rien'].sort, cls.synonym.sort
+  end
+
+  def test_label_main_lang_not_found
+    cls = parse_and_get_class lang: [:ES]
+
+    assert_empty cls.label
+    assert_equal 'skos prefLabel rien', cls.prefLabel
+    assert_equal ['entita esp' , 'entite rien' ].sort, cls.synonym.sort
+  end
+
+  def test_label_secondary_lang
+    # This feature is obsolete with the request language feature
+    # 'es' will not be found
+    cls = parse_and_get_class lang: %i[ES FR]
+
+    assert_empty cls.label
+    assert_equal 'skos prefLabel rien', cls.prefLabel
+    assert_equal ['entita esp', 'entite rien'].sort, cls.synonym.sort
+  end
+
+  def test_label_main_lang_en_found
+    cls = parse_and_get_class lang: [:EN]
+    assert_equal 'material detailed entity', cls.label.first
+    assert_includes ['skos prefLabel en', 'skos prefLabel rien'], cls.prefLabel # TODO fix in Goo to show en in priority
+    assert_equal ['entity eng', 'entite rien'].sort, cls.synonym.sort
+  end
+
+
+  private
+
+  def parse_and_get_class(lang:, klass: 'http://lirmm.fr/2015/resource/AGROOE_c_03')
+    portal_lang_set portal_languages: lang
+
+    cls = get_class(klass,'AGROOE')
+    assert !cls.nil?
+    cls.bring_remaining
+    cls
+  end
+
+
+  def portal_lang_set(portal_languages: nil)
+    Goo.main_languages = portal_languages if portal_languages
+    RequestStore.store[:requested_lang] = nil
+  end
+
+
+  def get_class(cls, ont)
+    sub = LinkedData::Models::Ontology.find(ont).first.latest_submission
+    LinkedData::Models::Class.find(cls).in(sub).first
+  end
+end

--- a/test/models/test_class_request_lang.rb
+++ b/test/models/test_class_request_lang.rb
@@ -1,0 +1,119 @@
+require_relative './test_ontology_common'
+require 'request_store'
+
+class TestClassRequestedLang < LinkedData::TestOntologyCommon
+
+  def self.before_suite
+    @@old_main_languages = Goo.main_languages
+    RequestStore.store[:requested_lang] = nil
+
+    parse
+  end
+
+  def self.after_suite
+    Goo.main_languages = @@old_main_languages
+    RequestStore.store[:requested_lang] = nil
+  end
+
+  def self.parse
+    new('').submission_parse('INRAETHES', 'Testing skos',
+                             'test/data/ontology_files/thesaurusINRAE_nouv_structure.skos', 1,
+                             process_rdf: true, index_search: false,
+                             run_metrics: false, reasoning: false
+    )
+  end
+
+  def teardown
+    reset_lang
+  end
+
+  def test_requested_language_found
+
+    cls = get_class_by_lang('http://opendata.inrae.fr/thesaurusINRAE/c_22817',
+                            requested_lang: :FR)
+    assert_equal 'industrialisation', cls.prefLabel
+    assert_equal ['développement industriel'], cls.synonym
+
+    properties = cls.properties
+    assert_equal ['développement industriel'], properties.select { |x| x.to_s['altLabel'] }.values.first.map(&:to_s)
+    assert_equal ['industrialisation'], properties.select { |x| x.to_s['prefLabel'] }.values.first.map(&:to_s)
+
+    cls = get_class_by_lang('http://opendata.inrae.fr/thesaurusINRAE/c_22817',
+                            requested_lang: :EN)
+    assert_equal 'industrialization', cls.prefLabel
+    assert_equal ['industrial development'], cls.synonym
+
+    properties = cls.properties
+    assert_equal ['industrial development'], properties.select { |x| x.to_s['altLabel'] }.values.first.map(&:to_s)
+    assert_equal ['industrialization'], properties.select { |x| x.to_s['prefLabel'] }.values.first.map(&:to_s)
+
+    cls = get_class_by_lang('http://opendata.inrae.fr/thesaurusINRAE/c_13078',
+                            requested_lang: :FR)
+    assert_equal 'carbone renouvelable', cls.prefLabel
+
+  end
+
+  def test_requested_language_not_found
+
+    cls = get_class_by_lang('http://opendata.inrae.fr/thesaurusINRAE/c_22817',
+                            requested_lang: :ES)
+    assert_nil cls.prefLabel
+    assert_empty cls.synonym
+
+    properties = cls.properties
+    assert_empty properties.select { |x| x.to_s['altLabel'] }.values
+    assert_empty properties.select { |x| x.to_s['prefLabel'] }.values
+  end
+
+  def test_request_all_languages
+
+    cls = get_class_by_lang('http://opendata.inrae.fr/thesaurusINRAE/c_22817',
+                            requested_lang: :ALL)
+
+    pref_label_all_languages = { en: 'industrialization', fr: 'industrialisation' }
+    assert_includes pref_label_all_languages.values, cls.prefLabel
+    assert_equal pref_label_all_languages, cls.prefLabel(include_languages: true)
+
+    synonym_all_languages = { en: ['industrial development'], fr: ['développement industriel'] }
+
+    assert_equal synonym_all_languages.values.flatten.sort, cls.synonym.sort
+    assert_equal synonym_all_languages, cls.synonym(include_languages: true)
+
+    properties = cls.properties
+
+    assert_equal synonym_all_languages.values.flatten.sort, properties.select { |x| x.to_s['altLabel'] }.values.first.map(&:to_s).sort
+    assert_equal pref_label_all_languages.values.sort, properties.select { |x| x.to_s['prefLabel'] }.values.first.map(&:to_s).sort
+
+    properties = cls.properties(include_languages: true)
+
+    assert_equal synonym_all_languages,
+                 properties.select { |x| x.to_s['altLabel'] }.values.first.transform_values{|v| v.map(&:object)}
+    assert_equal pref_label_all_languages,
+                 properties.select { |x| x.to_s['prefLabel'] }.values.first.transform_values{|v| v.first.object}
+  end
+
+  private
+
+  def lang_set(requested_lang: nil, portal_languages: nil)
+    Goo.main_languages = portal_languages if portal_languages
+    RequestStore.store[:requested_lang] = requested_lang
+  end
+
+  def reset_lang
+    lang_set requested_lang: nil, portal_languages: @@old_main_languages
+  end
+
+  def get_class(cls, ont)
+    sub = LinkedData::Models::Ontology.find(ont).first.latest_submission
+    LinkedData::Models::Class.find(cls).in(sub).first
+  end
+
+  def get_class_by_lang(cls, requested_lang:, portal_languages: nil)
+    lang_set requested_lang: requested_lang, portal_languages: portal_languages
+    cls = get_class(cls, 'INRAETHES')
+    refute_nil cls
+    cls.bring_remaining
+    cls.bring :unmapped
+    cls
+  end
+end

--- a/test/models/test_metric.rb
+++ b/test/models/test_metric.rb
@@ -24,6 +24,9 @@ class TestMetric < LinkedData::TestCase
     os.submissionId = id
     os.contact = [contact]
     os.released = DateTime.now - 4
+    os.description = "description example"
+    os.status = 'beta'
+    os.URI = RDF::URI.new('https://test.com')
     bogus.name = name
     o = LinkedData::Models::Ontology.find(acronym)
     if o.nil?

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -4,6 +4,10 @@ require "rack"
 
 class TestOntologySubmission < LinkedData::TestOntologyCommon
 
+  def setup
+    LinkedData::TestCase.backend_4s_delete
+  end
+
   def test_valid_ontology
 
     acronym = "BRO-TST"
@@ -33,6 +37,9 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
     os.uploadFilePath = uploadFilePath
     os.hasOntologyLanguage = owl
     os.ontology = bogus
+    os.URI = RDF::URI.new('https://test.com')
+    os.description = 'description example'
+    os.status = 'beta'
     assert os.valid?
   end
 
@@ -49,6 +56,9 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
     uploadFilePath = LinkedData::Models::OntologySubmission.copy_file_repository(acronym, id, ontologyFile)
     ont_submision.contact = [contact]
     ont_submision.released = DateTime.now - 4
+    ont_submision.URI = RDF::URI.new('https://test.com')
+    ont_submision.description = 'description example'
+    ont_submision.status = 'beta'
     ont_submision.uploadFilePath = uploadFilePath
     ont_submision.hasOntologyLanguage = owl
     ont_submision.ontology = rad
@@ -68,7 +78,6 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
     ont_submision.masterFileName = ont_submision.errors[:uploadFilePath][0][:options][0]
     assert ont_submision.valid?
     assert_equal 0, ont_submision.errors.length
-    LinkedData::TestCase.backend_4s_delete
   end
 
   def test_automaster_from_zip
@@ -101,6 +110,9 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
     ont_submision.contact = [contact]
     ont_submision.released = DateTime.now - 4
     ont_submision.hasOntologyLanguage = owl
+    ont_submision.uri = RDF::URI.new('https://test.com')
+    ont_submision.description = 'description example'
+    ont_submision.status = 'beta'
     ont_submision.ontology = dup
     assert (!ont_submision.valid?)
     assert_equal 1, ont_submision.errors.length
@@ -116,26 +128,26 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
 
     sub = LinkedData::Models::OntologySubmission.where(ontology: [acronym: "SKOS-TEST"],
                                                        submissionId: 987)
-                                                     .include(:version)
-                                                     .first
+                                                .include(:version)
+                                                .first
     assert sub.roots.map { |x| x.id.to_s}.sort == ["http://www.ebi.ac.uk/efo/EFO_0000311",
-       "http://www.ebi.ac.uk/efo/EFO_0001444",
-        "http://www.ifomis.org/bfo/1.1/snap#Disposition",
-         "http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:37577",
-          "http://www.ebi.ac.uk/efo/EFO_0000635",
-           "http://www.ebi.ac.uk/efo/EFO_0000324"].sort
+                                                   "http://www.ebi.ac.uk/efo/EFO_0001444",
+                                                   "http://www.ifomis.org/bfo/1.1/snap#Disposition",
+                                                   "http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:37577",
+                                                   "http://www.ebi.ac.uk/efo/EFO_0000635",
+                                                   "http://www.ebi.ac.uk/efo/EFO_0000324"].sort
     roots = sub.roots
     LinkedData::Models::Class.in(sub).models(roots).include(:children).all
     roots.each do |root|
-q_broader = <<-eos
+      q_broader = <<-eos
 SELECT ?children WHERE {
   ?children #{RDF::SKOS[:broader].to_ntriples} #{root.id.to_ntriples} }
 eos
-    children_query = []
-    Goo.sparql_query_client.query(q_broader).each_solution do |sol|
-      children_query << sol[:children].to_s
-    end
-    assert root.children.map { |x| x.id.to_s }.sort == children_query.sort
+      children_query = []
+      Goo.sparql_query_client.query(q_broader).each_solution do |sol|
+        children_query << sol[:children].to_s
+      end
+      assert root.children.map { |x| x.id.to_s }.sort == children_query.sort
     end
   end
 
@@ -147,11 +159,11 @@ eos
     #test for version info
     sub = LinkedData::Models::OntologySubmission.where(ontology: [acronym: "HP-TEST"],
                                                        submissionId: 55)
-                                                     .include(:version)
-                                                     .first
+                                                .include(:version)
+                                                .first
 
     paging = LinkedData::Models::Class.in(sub).page(1,100)
-                                              .include(:unmapped)
+                                      .include(:unmapped)
     found = false
 
     begin
@@ -182,7 +194,7 @@ eos
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT * WHERE {
   <http://purl.obolibrary.org/obo/TAO_0001044> rdfs:subClassOf ?x . }
-eos
+    eos
     count = 0
     Goo.sparql_query_client.query(qthing).each_solution do |sol|
       count += 1
@@ -193,7 +205,7 @@ eos
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
   SELECT DISTINCT * WHERE {
   <http://purl.obolibrary.org/obo/TAO_0001044> <http://data.bioontology.org/metadata/treeView> ?x . }
-eos
+    eos
     count = 0
     Goo.sparql_query_client.query(qthing).each_solution do |sol|
       count += 1
@@ -206,7 +218,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT * WHERE {
 <http://purl.obolibrary.org/obo/TAO_0001044>
   <http://data.bioontology.org/metadata/obo/part_of> ?x . }
-eos
+    eos
     count = 0
     Goo.sparql_query_client.query(qcount).each_solution do |sol|
       count += 1
@@ -220,24 +232,24 @@ eos
     #strict comparison to be sure the merge with the tree_view branch goes fine
 
     LinkedData::Models::Class.where.in(sub).include(:prefLabel,:synonym,:notation).each do |cls|
-        assert_instance_of String,cls.prefLabel
-        if cls.notation.nil?
-          assert false,"notation empty"
-        end
-        assert_instance_of String,cls.notation
-        assert cls.notation[-6..-1] == cls.id.to_s[-6..-1]
-        #NCBO-1007 - hasNarrowSynonym
-        if cls.id.to_s["CL_0000003"]
-          assert cls.synonym[0] == "cell in vivo"
-        end
-        #NCBO-1007 - hasBroadSynonym
-        if cls.id.to_s["CL_0000137"]
-          assert cls.synonym[0] == "bone cell"
-        end
-        #NCBO-1007 - hasRelatedSynonym
-        if cls.id.to_s["TAO_0000223"]
-          assert cls.synonym.length == 6
-        end
+      assert_instance_of String,cls.prefLabel
+      if cls.notation.nil?
+        assert false,"notation empty"
+      end
+      assert_instance_of String,cls.notation
+      assert cls.notation[-6..-1] == cls.id.to_s[-6..-1]
+      #NCBO-1007 - hasNarrowSynonym
+      if cls.id.to_s["CL_0000003"]
+        assert cls.synonym[0] == "cell in vivo"
+      end
+      #NCBO-1007 - hasBroadSynonym
+      if cls.id.to_s["CL_0000137"]
+        assert cls.synonym[0] == "bone cell"
+      end
+      #NCBO-1007 - hasRelatedSynonym
+      if cls.id.to_s["TAO_0000223"]
+        assert cls.synonym.length == 6
+      end
     end
 
     # This is testing that treeView is used to traverse the hierarchy
@@ -245,17 +257,17 @@ eos
     assert sub.hasOntologyLanguage.tree_property == Goo.vocabulary(:metadata)[:treeView]
 
     bm = LinkedData::Models::Class
-               .find(RDF::URI.new("http://purl.obolibrary.org/obo/GO_0070977"))
-               .in(sub)
-               .include(:prefLabel,:children,:parents)
-               .first
+           .find(RDF::URI.new("http://purl.obolibrary.org/obo/GO_0070977"))
+           .in(sub)
+           .include(:prefLabel,:children,:parents)
+           .first
     assert bm.children.first.id == RDF::URI.new("http://purl.obolibrary.org/obo/GO_0043931")
     assert_equal 2, bm.parents.length
     roots = sub.roots
     assert roots.map { |x| x.id.to_s }.sort ==
-      ["http://purl.obolibrary.org/obo/PATO_0000001",
-      "http://purl.obolibrary.org/obo/CARO_0000000",
-      "http://purl.obolibrary.org/obo/GO_0008150"].sort
+             ["http://purl.obolibrary.org/obo/PATO_0000001",
+              "http://purl.obolibrary.org/obo/CARO_0000000",
+              "http://purl.obolibrary.org/obo/GO_0008150"].sort
   end
 
   def test_submission_parse_subfolders_zip
@@ -263,8 +275,7 @@ eos
                      "./test/data/ontology_files/XCTontologyvtemp2_vvtemp2.zip",
                      34,
                      masterFileName: "XCTontologyvtemp2/XCTontologyvtemp2.owl",
-                     process_rdf: true, index_search: false,
-                     run_metrics: false, reasoning: true)
+                     process_rdf: true, extract_metadata: false, generate_missing_labels: false)
 
     sub = LinkedData::Models::OntologySubmission.where(ontology: [acronym: "CTXTEST"]).first
 
@@ -278,53 +289,43 @@ eos
     # This one has some nasty looking IRIS with slashes in the anchor
     unless ENV["BP_SKIP_HEAVY_TESTS"] == "1"
       submission_parse("MCCLTEST", "MCCLS TEST",
-                 "./test/data/ontology_files/CellLine_OWL_BioPortal_v1.0.owl", 11,
-                       process_rdf: true, index_search: true,
-                       run_metrics: false, reasoning: true)
+                         "./test/data/ontology_files/CellLine_OWL_BioPortal_v1.0.owl", 11,
+                         process_rdf: true, extract_metadata: false)
 
       sub = LinkedData::Models::OntologySubmission.where(ontology: [acronym: "MCCLTEST"],
                                                          submissionId: 11)
-                                                       .include(:version)
-                                                       .first
+                                                  .include(:version)
+                                                  .first
       assert sub.version == "3.0"
     end
 
     #This one has resources wih accents.
     submission_parse("ONTOMATEST",
-                     "OntoMA TEST",
-                     "./test/data/ontology_files/OntoMA.1.1_vVersion_1.1_Date__11-2011.OWL", 15,
-                     process_rdf: true, index_search: true,
-                     run_metrics: false, reasoning: true)
+                       "OntoMA TEST",
+                       "./test/data/ontology_files/OntoMA.1.1_vVersion_1.1_Date__11-2011.OWL", 15,
+                       process_rdf: true, extract_metadata: false)
 
     sub = LinkedData::Models::OntologySubmission.where(ontology: [acronym: "ONTOMATEST"],
                                                        submissionId: 15)
-                                                     .include(:version)
-                                                     .first
+                                                .include(:version)
+                                                .first
     assert sub.version["Version 1.1"]
     assert sub.version["Date: 11-2011"]
   end
 
   def test_process_submission_diff
-    # Cleanup
-    LinkedData::TestCase.backend_4s_delete
     acronym = 'BRO'
     # Create a 1st version for BRO
     submission_parse(acronym, "BRO",
-                     "./test/data/ontology_files/BRO_v3.4.owl", 1,
-                     process_rdf: true, index_search: false,
-                     run_metrics: false, reasoning: false,
-                     diff: true, delete: false)
+                     "./test/data/ontology_files/BRO_v3.4.owl", 1, process_rdf: false)
     # Create a later version for BRO
     submission_parse(acronym, "BRO",
-                     "./test/data/ontology_files/BRO_v3.5.owl", 2,
-                     process_rdf: true, index_search: false,
-                     run_metrics: false, reasoning: false,
-                     diff: true, delete: false)
-    onts = LinkedData::Models::Ontology.find(acronym)
-    bro = onts.first
-    bro.bring(:submissions)
+                     "./test/data/ontology_files/BRO_v3.5.owl", 2, process_rdf: false, diff: true, delete: false)
+
+    bro = LinkedData::Models::Ontology.find(acronym).include(submissions:[:submissionId,:diffFilePath]).first
+    #bro.bring(:submissions)
     submissions = bro.submissions
-    submissions.each {|s| s.bring(:submissionId, :diffFilePath)}
+    #submissions.each {|s| s.bring(:submissionId, :diffFilePath)}
     # Sort submissions in descending order of submissionId, extract last two submissions
     recent_submissions = submissions.sort {|a,b| b.submissionId <=> a.submissionId}[0..1]
     sub1 = recent_submissions.last  # descending order, so last is older submission
@@ -332,17 +333,18 @@ eos
     assert(sub1.submissionId < sub2.submissionId, 'submissionId is in the wrong order')
     assert(sub1.diffFilePath == nil, 'Should not create diff for older submission.')
     assert(sub2.diffFilePath != nil, 'Failed to create diff for the latest submission.')
-    # Cleanup
-    LinkedData::TestCase.backend_4s_delete
   end
 
   def test_process_submission_archive
-    parse_options = { process_rdf: false, index_search: false, index_commit: false,
-                      run_metrics: false, reasoning: false, archive: true }
+
+    old_threshold = LinkedData::Services::OntologySubmissionArchiver::FILE_SIZE_ZIPPING_THRESHOLD
+    LinkedData::Services::OntologySubmissionArchiver.const_set(:FILE_SIZE_ZIPPING_THRESHOLD, 0)
 
     ont_count, ont_acronyms, ontologies =
       create_ontologies_and_submissions(ont_count: 1, submission_count: 2,
-                                        process_submission: true, acronym: 'NCBO-545')
+                                        process_submission: true,
+                                        acronym: 'NCBO-545', process_options: {process_rdf: true, index_search: true,
+                                                                               extract_metadata: false})
     # Sanity check.
     assert_equal 1, ontologies.count
     assert_equal 2, ontologies.first.submissions.count
@@ -352,51 +354,59 @@ eos
 
     # Process latest submission.  No files should be deleted.
     latest_sub = sorted_submissions.first
-    latest_sub.process_submission(Logger.new(latest_sub.parsing_log_path), parse_options)
-    assert latest_sub.archived?
+    latest_sub.process_submission(Logger.new(latest_sub.parsing_log_path), {archive: true})
+
+    refute latest_sub.archived?
 
     assert File.file?(File.join(latest_sub.data_folder, 'labels.ttl')),
-      %-Missing ontology submission file: 'labels.ttl'-
+           %-Missing ontology submission file: 'labels.ttl'-
 
     assert File.file?(File.join(latest_sub.data_folder, 'owlapi.xrdf')),
-      %-Missing ontology submission file: 'owlapi.xrdf'-
+           %-Missing ontology submission file: 'owlapi.xrdf'-
 
     assert File.file?(latest_sub.csv_path),
-      %-Missing ontology submission file: '#{latest_sub.csv_path}'-
+           %-Missing ontology submission file: '#{latest_sub.csv_path}'-
 
     assert File.file?(latest_sub.parsing_log_path),
-      %-Missing ontology submission file: '#{latest_sub.parsing_log_path}'-
+           %-Missing ontology submission file: '#{latest_sub.parsing_log_path}'-
 
     # Process one prior to latest submission.  Some files should be deleted.
     old_sub = sorted_submissions.last
-    old_sub.process_submission(Logger.new(old_sub.parsing_log_path), parse_options)
+    old_file_path = old_sub.uploadFilePath
+    old_sub.process_submission(Logger.new(old_sub.parsing_log_path), {archive: true})
     assert old_sub.archived?
 
-    assert_equal false, File.file?(File.join(old_sub.data_folder, 'labels.ttl')),
-      %-File deletion failed for 'labels.ttl'-
+    refute File.file?(File.join(old_sub.data_folder, 'labels.ttl')),
+                 %-File deletion failed for 'labels.ttl'-
 
-    assert_equal false, File.file?(File.join(old_sub.data_folder, 'mappings.ttl')),
-      %-File deletion failed for 'mappings.ttl'-
+    refute File.file?(File.join(old_sub.data_folder, 'mappings.ttl')),
+                 %-File deletion failed for 'mappings.ttl'-
 
-    assert_equal false, File.file?(File.join(old_sub.data_folder, 'obsolete.ttl')),
-      %-File deletion failed for 'obsolete.ttl'-
+    refute File.file?(File.join(old_sub.data_folder, 'obsolete.ttl')),
+                 %-File deletion failed for 'obsolete.ttl'-
 
-    assert_equal false, File.file?(File.join(old_sub.data_folder, 'owlapi.xrdf')),
-      %-File deletion failed for 'owlapi.xrdf'-
+    refute File.file?(File.join(old_sub.data_folder, 'owlapi.xrdf')),
+                 %-File deletion failed for 'owlapi.xrdf'-
 
-    assert_equal false, File.file?(old_sub.csv_path),
-      %-File deletion failed for '#{old_sub.csv_path}'-
+    refute File.file?(old_sub.csv_path),
+                 %-File deletion failed for '#{old_sub.csv_path}'-
 
-    assert_equal false, File.file?(old_sub.parsing_log_path),
+    refute File.file?(old_sub.parsing_log_path),
       %-File deletion failed for '#{old_sub.parsing_log_path}'-
+
+    refute File.file?(old_file_path),
+                 %-File deletion failed for '#{old_file_path}'-
+
+    assert old_sub.zipped?
+    assert File.file?(old_sub.uploadFilePath)
+    LinkedData::Models::OntologySubmission.const_set(:FILE_SIZE_ZIPPING_THRESHOLD, old_threshold)
   end
 
   def test_submission_diff_across_ontologies
     # Create a 1st version for BRO
     submission_parse("BRO34", "BRO3.4",
                      "./test/data/ontology_files/BRO_v3.4.owl", 1,
-                     process_rdf: true, index_search: false,
-                     run_metrics: false, reasoning: false)
+                     process_rdf: false)
     onts = LinkedData::Models::Ontology.find('BRO34')
     bro34 = onts.first
     bro34.bring(:submissions)
@@ -404,8 +414,7 @@ eos
     # Create a later version for BRO
     submission_parse("BRO35", "BRO3.5",
                      "./test/data/ontology_files/BRO_v3.5.owl", 1,
-                     process_rdf: true, index_search: false,
-                     run_metrics: false, reasoning: false)
+                     process_rdf: false)
     onts = LinkedData::Models::Ontology.find('BRO35')
     bro35 = onts.first
     bro35.bring(:submissions)
@@ -419,7 +428,7 @@ eos
   def test_index_properties
     submission_parse("BRO", "BRO Ontology",
                      "./test/data/ontology_files/BRO_v3.5.owl", 1,
-                     process_rdf: true, reasoning: false, index_properties: true)
+                     process_rdf: true, extract_metadata: false, index_properties: true)
     res = LinkedData::Models::Class.search("*:*", {:fq => "submissionAcronym:\"BRO\"", :start => 0, :rows => 80}, :property)
     assert_equal 80, res["response"]["numFound"]
     found = 0
@@ -453,6 +462,48 @@ eos
     assert_equal 0, res["response"]["numFound"]
   end
 
+
+  def test_zipped_submission_process
+    acronym = "PIZZA"
+    name = "PIZZA Ontology"
+    ontologyFile = "./test/data/ontology_files/pizza.owl.zip"
+    archived_submission = nil
+    2.times do |i|
+      id = 20 + i
+      ont_submision =  LinkedData::Models::OntologySubmission.new({ :submissionId => id})
+      assert (not ont_submision.valid?)
+      assert_equal 4, ont_submision.errors.length
+      uploadFilePath = LinkedData::Models::OntologySubmission.copy_file_repository(acronym, id,ontologyFile)
+      ont_submision.uploadFilePath = uploadFilePath
+      owl, bro, user, contact = submission_dependent_objects("OWL", acronym, "test_linked_models", name)
+      ont_submision.released = DateTime.now - 4
+      ont_submision.hasOntologyLanguage = owl
+      ont_submision.ontology = bro
+      ont_submision.contact = [contact]
+      ont_submision.URI = RDF::URI.new("https://test-#{id}.com")
+      ont_submision.description =  "Description #{id}"
+      ont_submision.status = 'production'
+      assert ont_submision.valid?
+      ont_submision.save
+      parse_options = {process_rdf: false, diff: true}
+      begin
+        tmp_log = Logger.new(TestLogFile.new)
+        ont_submision.process_submission(tmp_log, parse_options)
+      rescue Exception => e
+        puts "Error, logged in #{tmp_log.instance_variable_get("@logdev").dev.path}"
+        raise e
+      end
+      archived_submission = ont_submision if i.zero?
+    end
+    parse_options = { process_rdf: false,  archive: true }
+    archived_submission.process_submission(Logger.new(TestLogFile.new), parse_options)
+
+    assert_equal false, File.file?(archived_submission.zip_folder),
+                 %-File deletion failed for '#{archived_submission.zip_folder}'-
+
+
+
+  end
   def test_submission_parse_zip
     skip if ENV["BP_SKIP_HEAVY_TESTS"] == "1"
 
@@ -468,6 +519,9 @@ eos
     LinkedData::TestCase.backend_4s_delete
 
     ont_submision =  LinkedData::Models::OntologySubmission.new({ :submissionId => id,})
+    ont_submision.uri = RDF::URI.new('https://test.com')
+    ont_submision.description = 'description example'
+    ont_submision.status = 'beta'
     assert (not ont_submision.valid?)
     assert_equal 4, ont_submision.errors.length
     uploadFilePath = LinkedData::Models::OntologySubmission.copy_file_repository(acronym, id,ontologyFile)
@@ -547,17 +601,7 @@ eos
 
   def test_download_ontology_file
     begin
-      server_port = Random.rand(55000..65535) # http://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Dynamic.2C_private_or_ephemeral_ports
-      server_url = 'http://localhost:' + server_port.to_s
-      server_thread = Thread.new do
-        Rack::Server.start(
-            app: lambda do |e|
-              [200, {'Content-Type' => 'text/plain'}, ['test file']]
-            end,
-            Port: server_port
-        )
-      end
-      Thread.pass
+      server_url, server_thread, server_port  = start_server
       sleep 3  # Allow the server to startup
       assert(server_thread.alive?, msg="Rack::Server thread should be alive, it's not!")
       ont_count, ont_names, ont_models = create_ontologies_and_submissions(ont_count: 1, submission_count: 1)
@@ -712,7 +756,7 @@ eos
     acr = "CSTPROPS"
     init_test_ontology_msotest acr
     os = LinkedData::Models::OntologySubmission.where(ontology: [ acronym: acr ], submissionId: 1)
-          .include(LinkedData::Models::OntologySubmission.attributes).all
+                                               .include(LinkedData::Models::OntologySubmission.attributes).all
     assert(os.length == 1)
     os = os[0]
     roots = os.roots
@@ -756,8 +800,6 @@ eos
 
     roots = os.roots(nil, 1, 300)
     assert_equal 6, roots.length
-
-    LinkedData::TestCase.backend_4s_delete
   end
 
   #escaping sequences
@@ -767,9 +809,7 @@ eos
     ontologyFile = "./test/data/ontology_files/SBO.obo"
     id = 10
 
-    LinkedData::TestCase.backend_4s_delete
-
-    ont_submision =  LinkedData::Models::OntologySubmission.new({ :submissionId => id,})
+    ont_submision =  LinkedData::Models::OntologySubmission.new({ :submissionId => id })
     uploadFilePath = LinkedData::Models::OntologySubmission.copy_file_repository(acronym, id,ontologyFile)
     ont_submision.uploadFilePath = uploadFilePath
     owl, sbo, user, contact = submission_dependent_objects("OBO", acronym, "test_linked_models", name)
@@ -777,13 +817,16 @@ eos
     ont_submision.hasOntologyLanguage = owl
     ont_submision.contact = [contact]
     ont_submision.ontology = sbo
+    ont_submision.uri = RDF::URI.new('https://test.com')
+    ont_submision.description = 'description example'
+    ont_submision.status = 'beta'
     assert (ont_submision.valid?)
     ont_submision.save
     assert_equal true, ont_submision.exist?(reload=true)
 
     sub = LinkedData::Models::OntologySubmission.where(ontology: [ acronym: acronym ], submissionId: id).all
     sub = sub[0]
-    parse_options = {process_rdf: true, index_search: false, run_metrics: false, reasoning: true}
+    parse_options = {process_rdf: true, extract_metadata: false}
     begin
       tmp_log = Logger.new(TestLogFile.new)
       sub.process_submission(tmp_log, parse_options)
@@ -793,8 +836,8 @@ eos
     end
     assert sub.ready?({status: [:uploaded, :rdf, :rdf_labels]})
     page_classes = LinkedData::Models::Class.in(sub)
-                                             .page(1,1000)
-                                             .include(:prefLabel, :synonym).all
+                                            .page(1,1000)
+                                            .include(:prefLabel, :synonym).all
     page_classes.each do |c|
       if c.id.to_s == "http://purl.obolibrary.org/obo/SBO_0000004"
         assert c.prefLabel == "modelling framework"
@@ -812,7 +855,6 @@ eos
       end
     end
 
-    LinkedData::TestCase.backend_4s_delete
   end
 
   #ontology with import errors
@@ -822,7 +864,6 @@ eos
     ontologyFile = "./test/data/ontology_files/CNO_05.owl"
     id = 10
 
-    LinkedData::TestCase.backend_4s_delete
 
     ont_submision =  LinkedData::Models::OntologySubmission.new({ :submissionId => id,})
     uploadFilePath = LinkedData::Models::OntologySubmission.copy_file_repository(acronym, id,ontologyFile)
@@ -831,6 +872,9 @@ eos
     ont_submision.released = DateTime.now - 4
     ont_submision.hasOntologyLanguage = owl
     ont_submision.ontology = cno
+    ont_submision.uri = RDF::URI.new('https://test.com')
+    ont_submision.description = 'description example'
+    ont_submision.status = 'beta'
     ont_submision.contact = [contact]
     assert (ont_submision.valid?)
     ont_submision.save
@@ -838,7 +882,7 @@ eos
     sub = LinkedData::Models::OntologySubmission.where(ontology: [ acronym: acronym ], submissionId: id).all
     sub = sub[0]
     #this is the only ontology that indexes and tests for no error
-    parse_options = {process_rdf: true, index_search: true, run_metrics: false, reasoning: true}
+    parse_options = {process_rdf: true, extract_metadata: false}
     begin
       tmp_log = Logger.new(TestLogFile.new)
       sub.process_submission(tmp_log, parse_options)
@@ -852,12 +896,11 @@ eos
     sub.submissionStatus.select { |x| x.id.to_s["ERROR"] }.length == 0
 
     LinkedData::Models::Class.where.in(sub)
-      .include(:prefLabel, :notation, :prefixIRI).each do |cls|
+                             .include(:prefLabel, :notation, :prefixIRI).each do |cls|
       assert !cls.notation.nil? || !cls.prefixIRI.nil?
       assert !cls.id.to_s.start_with?(":")
     end
 
-    LinkedData::TestCase.backend_4s_delete
   end
 
   #multiple preflables
@@ -939,9 +982,9 @@ eos
     assert count_headers > 2
 
     page_classes = LinkedData::Models::Class.in(sub)
-                                             .page(1,1000)
-                                             .read_only
-                                             .include(:prefLabel, :synonym, :definition).all
+                                            .page(1,1000)
+                                            .read_only
+                                            .include(:prefLabel, :synonym, :definition).all
     page_classes.each do |c|
       if c.id.to_s == "http://purl.obolibrary.org/obo/AERO_0000040"
         assert c.prefLabel == "shaking finding"
@@ -961,7 +1004,7 @@ eos
 
     #for indexing in search
     paging = LinkedData::Models::Class.in(sub).page(1,100)
-                                              .include(:unmapped)
+                                      .include(:unmapped)
     page = nil
     defs = 0
     syns = 0
@@ -983,8 +1026,7 @@ eos
   def test_submission_metrics
     submission_parse("CDAOTEST", "CDAOTEST testing metrics",
                      "./test/data/ontology_files/cdao_vunknown.owl", 22,
-                     process_rdf: true, index_search: false,
-                     run_metrics: true, reasoning: true)
+                     process_rdf: true, run_metrics: true, extract_metadata: false)
     sub = LinkedData::Models::Ontology.find("CDAOTEST").first.latest_submission(status: [:rdf, :metrics])
     sub.bring(:metrics)
 
@@ -1004,8 +1046,8 @@ eos
 
     submission_parse("BROTEST-METRICS", "BRO testing metrics",
                      "./test/data/ontology_files/BRO_v3.2.owl", 33,
-                     process_rdf: true, index_search: false,
-                     run_metrics: true, reasoning: true)
+                     process_rdf: true, extract_metadata: false,
+                     run_metrics: true)
     sub = LinkedData::Models::Ontology.find("BROTEST-METRICS").first.latest_submission(status: [:rdf, :metrics])
     sub.bring(:metrics)
 
@@ -1036,11 +1078,11 @@ eos
 
     submission_parse("BROTEST-ISFLAT", "BRO testing metrics flat",
                      "./test/data/ontology_files/BRO_v3.2.owl", 33,
-                     process_rdf: true, index_search: false,
-                     run_metrics: true, reasoning: true)
+                     process_rdf: true, extract_metadata: false,
+                     run_metrics: true)
 
     sub = LinkedData::Models::Ontology.find("BROTEST-ISFLAT").first
-      .latest_submission(status: [:rdf, :metrics])
+                                      .latest_submission(status: [:rdf, :metrics])
     sub.bring(:metrics)
     metrics = sub.metrics
     metrics.bring_remaining
@@ -1057,12 +1099,11 @@ eos
     assert_equal 0, metrics.maxChildCount
     assert_equal 0, metrics.averageChildCount
 
-
     #test UMLS metrics
     acronym = 'UMLS-TST'
     submission_parse(acronym, "Test UMLS Ontologory", "./test/data/ontology_files/umls_semantictypes.ttl", 1,
-                     process_rdf: true, index_search: false,
-                     run_metrics: true, reasoning: true)
+                     process_rdf: true, extract_metadata: false,
+                     run_metrics: true)
     sub = LinkedData::Models::Ontology.find(acronym).first.latest_submission(status: [:rdf, :metrics])
     sub.bring(:metrics)
     metrics = sub.metrics
@@ -1070,13 +1111,34 @@ eos
     assert_equal 133, metrics.classes
   end
 
+  # To test extraction of metadata when parsing a submission (we extract the submission attributes that have the
+  # extractedMetadata on true)
+  def test_submission_extract_metadata
+    2.times.each do |i|
+      submission_parse("AGROOE", "AGROOE Test extract metadata ontology",
+                       "./test/data/ontology_files/agrooeMappings-05-05-2016.owl", i+1,
+                       process_rdf: true, extract_metadata: true, generate_missing_labels: false)
+      ont =  LinkedData::Models::Ontology.find("AGROOE").first
+      sub = ont.latest_submission
+      refute_nil sub
+
+      # sub.bring_remaining
+      # assert_equal '2015-09-28', sub.creationDate.to_date.to_s
+      # assert_equal '2015-10-01', sub.modificationDate.to_date.to_s
+      # assert_equal  "description example,  AGROOE is an ontology used to test the metadata extraction,  AGROOE is an ontology to illustrate how to describe their ontologies", sub.description
+      # assert_equal ["http://lexvo.org/id/iso639-3/fra", "http://lexvo.org/id/iso639-3/eng"].sort, sub.naturalLanguage.sort
+      # sub.description = "test changed value"
+      # sub.save
+    end
+  end
+
+
   def test_submission_delete_remove_files
     #This one has resources wih accents.
     submission_parse("ONTOMATEST",
                      "OntoMA TEST",
                      "./test/data/ontology_files/OntoMA.1.1_vVersion_1.1_Date__11-2011.OWL", 15,
-                     process_rdf: true, index_search: true,
-                     run_metrics: false, reasoning: true)
+                     process_rdf: false)
 
     sub = LinkedData::Models::OntologySubmission.where(ontology: [acronym: "ONTOMATEST"],
                                                        submissionId: 15)

--- a/test/models/test_project.rb
+++ b/test/models/test_project.rb
@@ -90,7 +90,7 @@ class TestProject < LinkedData::TestCase
     users = Array.new(3) { LinkedData::Models::User.new }
     users.each_with_index do |user, i|
       user.username = "Test User #{i}"
-      user.email = 'test_user@example.org'
+      user.email = "test_user#{i}@example.org"
       user.password = 'password'
       user.save
       assert user.valid?, user.errors

--- a/test/models/test_provisional_class.rb
+++ b/test/models/test_provisional_class.rb
@@ -3,12 +3,11 @@ require_relative "./test_ontology_common"
 class TestProvisionalClass < LinkedData::TestOntologyCommon
 
   def self.before_suite
-    self._delete
-
     @@user = LinkedData::Models::User.new({username: "Test User", email: "tester@example.org", password: "password"})
     @@user.save
 
-    ont_count, ont_names, ont_models = LinkedData::SampleData::Ontology.create_ontologies_and_submissions(ont_count: 1, submission_count: 1)
+    ont_count, ont_names, ont_models = LinkedData::SampleData::Ontology.create_ontologies_and_submissions(ont_count: 1,
+                                                                                                          submission_count: 1)
     @@ontology = ont_models.first
     @@ontology.bring(:name)
     @@ontology.bring(:acronym)
@@ -21,15 +20,15 @@ class TestProvisionalClass < LinkedData::TestOntologyCommon
   def self.after_suite
     pc = LinkedData::Models::ProvisionalClass.find(@@provisional_class.id).first
     pc.delete unless pc.nil?
-    LinkedData::Models::Ontology.indexClear
-    LinkedData::Models::Ontology.indexCommit
-  end
 
-  def self._delete
+    LinkedData::Models::ProvisionalClass.indexClear
+    LinkedData::Models::ProvisionalClass.indexCommit
     LinkedData::SampleData::Ontology.delete_ontologies_and_submissions
     user = LinkedData::Models::User.find("Test User").first
     user.delete unless user.nil?
+
   end
+
 
   def test_provisional_class_lifecycle
     label = "Test Provisional Class Lifecycle"
@@ -71,7 +70,7 @@ class TestProvisionalClass < LinkedData::TestOntologyCommon
     pc_array = Array.new(3) { LinkedData::Models::ProvisionalClass.new }
     pc_array.each_with_index do |pc, i|
       pc.label = "Test PC #{i}"
-      pc.creator = LinkedData::Models::User.new({username: creators[i], email: "tester@example.org", password: "password"}).save
+      pc.creator = LinkedData::Models::User.new({username: creators[i], email: "tester#{i}@example.org", password: "password"}).save
       pc.save
       assert pc.valid?, "#{pc.errors}"
     end
@@ -91,7 +90,7 @@ class TestProvisionalClass < LinkedData::TestOntologyCommon
 
   def test_provisional_class_filter_by_creator
     username = "User Testing Filtering"
-    user = LinkedData::Models::User.new({username: username, email: "tester@example.org", password: "password"})
+    user = LinkedData::Models::User.new({username: username, email: "tester#{rand}@example.org", password: "password"})
     user.save
     assert user.valid?, "#{user.errors}"
 
@@ -292,7 +291,7 @@ class TestProvisionalClass < LinkedData::TestOntologyCommon
     pc.index
     resp = LinkedData::Models::Ontology.search("\"#{pc.label}\"", params)
     assert_equal 1, resp["response"]["numFound"]
-    assert_equal pc.label, resp["response"]["docs"][0]["prefLabel"]
+    assert_equal pc.label, resp["response"]["docs"][0]["prefLabel"].first
     pc.unindex
 
     acr = "CSTPROPS"
@@ -315,7 +314,7 @@ class TestProvisionalClass < LinkedData::TestOntologyCommon
 
     resp = LinkedData::Models::Ontology.search("\"#{pc1.label}\"", params)
     assert_equal 1, resp["response"]["numFound"]
-    assert_equal pc1.label, resp["response"]["docs"][0]["prefLabel"]
+    assert_equal pc1.label, resp["response"]["docs"][0]["prefLabel"].first
     par_len = resp["response"]["docs"][0]["parents"].length
     assert_equal 5, par_len
     assert_equal 1, (resp["response"]["docs"][0]["parents"].select { |x| x == class_id.to_s }).length

--- a/test/models/test_provisional_relation.rb
+++ b/test/models/test_provisional_relation.rb
@@ -2,52 +2,45 @@ require_relative "../test_case"
 
 class TestProvisionalRelation < LinkedData::TestCase
 
-  def setup
-    _delete
+  def self.before_suite
+    @@user = LinkedData::Models::User.new({username: "Test User", email: "tester@example.org", password: "password"})
+    @@user.save
 
-    @user = LinkedData::Models::User.new({username: "Test User", email: "tester@example.org", password: "password"})
-    assert @user.valid?, "Invalid User object #{@user.errors}"
-    @user.save
+    ont_count, ont_names, ont_models = self.new('').create_ontologies_and_submissions(ont_count: 1, submission_count: 1,
+                                                                         process_submission: true,
+                                                                         process_options: {process_rdf: true,
+                                                                                           extract_metadata: false})
 
-    ont_count, ont_names, ont_models = create_ontologies_and_submissions(ont_count: 1, submission_count: 1, process_submission: true)
-    @ontology = ont_models.first
-    @ontology.bring(:name)
-    @ontology.bring(:acronym)
-    @submission = @ontology.bring(:submissions).submissions.first
+    @@ontology = ont_models.first
+    @@ontology.bring(:name)
+    @@ontology.bring(:acronym)
+    @@submission = @@ontology.bring(:submissions).submissions.first
 
-    @provisional_class = LinkedData::Models::ProvisionalClass.new({label: "Test Provisional Class", creator: @user, ontology: @ontology})
-    assert @provisional_class.valid?, "Invalid ProvisionalClass object #{@provisional_class.errors}"
-    @provisional_class.save
+    @@provisional_class = LinkedData::Models::ProvisionalClass.new({label: "Test Provisional Class", creator: @@user, ontology: @@ontology})
+    @@provisional_class.save
 
-    @relation_type = RDF::IRI.new "http://www.w3.org/2004/02/skos/core#exactMatch"
+    @@relation_type = RDF::IRI.new "http://www.w3.org/2004/02/skos/core#exactMatch"
 
-    @target_class_uri1 = RDF::IRI.new "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Image_Algorithm"
-    @target_class_uri2 = RDF::IRI.new "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Integration_and_Interoperability_Tools"
+    @@target_class_uri1 = RDF::IRI.new "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Image_Algorithm"
+    @@target_class_uri2 = RDF::IRI.new "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Integration_and_Interoperability_Tools"
 
-    @provisional_rel1 = LinkedData::Models::ProvisionalRelation.new({creator: @user, source: @provisional_class, relationType: @relation_type, targetClassId: @target_class_uri1, targetClassOntology: @ontology})
-    assert @provisional_rel1.valid?, "Invalid ProvisionalRelation object #{@provisional_rel1.errors}"
-    @provisional_rel1.save
-    @provisional_rel2 = LinkedData::Models::ProvisionalRelation.new({creator: @user, source: @provisional_class, relationType: @relation_type, targetClassId: @target_class_uri2, targetClassOntology: @ontology})
-    assert @provisional_rel2.valid?, "Invalid ProvisionalRelation object #{@provisional_rel2.errors}"
-    @provisional_rel2.save
+    @@provisional_rel1 = LinkedData::Models::ProvisionalRelation.new({creator: @@user, source: @@provisional_class, relationType: @@relation_type, targetClassId: @@target_class_uri1, targetClassOntology: @@ontology})
+    @@provisional_rel1.save
+    @@provisional_rel2 = LinkedData::Models::ProvisionalRelation.new({creator: @@user, source: @@provisional_class, relationType: @@relation_type, targetClassId: @@target_class_uri2, targetClassOntology: @@ontology})
+    @@provisional_rel2.save
   end
 
-  def _delete
-    delete_ontologies_and_submissions
-    user = LinkedData::Models::User.find("Test User").first
-    user.delete unless user.nil?
-  end
 
   def test_create_provisional_relation
-    rel1 = LinkedData::Models::ProvisionalRelation.find(@provisional_rel1.id).first
+    rel1 = LinkedData::Models::ProvisionalRelation.find(@@provisional_rel1.id).first
     rel1.bring_remaining
     assert rel1.valid?
 
-    rel2 = LinkedData::Models::ProvisionalRelation.find(@provisional_rel2.id).first
+    rel2 = LinkedData::Models::ProvisionalRelation.find(@@provisional_rel2.id).first
     rel2.bring_remaining
     assert rel2.valid?
 
-    pc = LinkedData::Models::ProvisionalClass.find(@provisional_class.id).first
+    pc = LinkedData::Models::ProvisionalClass.find(@@provisional_class.id).first
     pc.bring(:relations)
 
     assert_equal 2, pc.relations.length
@@ -58,32 +51,23 @@ class TestProvisionalRelation < LinkedData::TestCase
   end
 
   def test_find_unique_provisional_relation
-    rel = LinkedData::Models::ProvisionalRelation.find_unique(@provisional_class.id, @relation_type, @target_class_uri1, @ontology.id)
-    assert_equal @provisional_rel1.id, rel.id
+    rel = LinkedData::Models::ProvisionalRelation.find_unique(@@provisional_class.id, @@relation_type, @@target_class_uri1, @@ontology.id)
+    assert_equal @@provisional_rel1.id, rel.id
   end
 
   def test_equals
-    rel = LinkedData::Models::ProvisionalRelation.find_unique(@provisional_class.id, @relation_type, @target_class_uri1, @ontology.id)
-    assert @provisional_rel1 == rel
+    rel = LinkedData::Models::ProvisionalRelation.find_unique(@@provisional_class.id, @@relation_type, @@target_class_uri1, @@ontology.id)
+    assert @@provisional_rel1 == rel
   end
 
   def test_target_class
-    target_class = @provisional_rel1.target_class
-    assert_equal @target_class_uri1, target_class.id
+    target_class = @@provisional_rel1.target_class
+    assert_equal @@target_class_uri1, target_class.id
     target_class.bring(:submission) if target_class.bring?(:submission)
     target_class.submission.bring(ontology: [:acronym]) if target_class.submission.bring?(:ontology)
-    assert_equal @ontology.acronym, target_class.submission.ontology.acronym
+    assert_equal @@ontology.acronym, target_class.submission.ontology.acronym
   end
 
-  def teardown
-    super
-    @provisional_class.delete
-    @provisional_rel1.delete
-    @provisional_rel2.delete
-    rel1 = LinkedData::Models::ProvisionalRelation.find(@provisional_rel1.id).first
-    assert_nil rel1
-    rel2 = LinkedData::Models::ProvisionalRelation.find(@provisional_rel2.id).first
-    assert_nil rel2
-  end
+
 
 end

--- a/test/rack/test_request_authorization.rb
+++ b/test/rack/test_request_authorization.rb
@@ -43,7 +43,7 @@ class TestRackAuthorization < MiniTest::Unit::TestCase
       user = LinkedData::Models::User.new({
         username: username,
         password: "test_password",
-        email: "test_email@example.org"
+        email: "test_email#{rand}@example.org"
       })
       user.save unless user.exist?
       users << user

--- a/test/util/test_notifications.rb
+++ b/test/util/test_notifications.rb
@@ -162,6 +162,9 @@ class TestNotifications < LinkedData::TestCase
   end
 
   def test_mail_options
+    current_auth_type = LinkedData.settings.smtp_auth_type
+
+    LinkedData.settings.smtp_auth_type = :none
     options = LinkedData::Utils::Notifier.mail_options
     expected_options = {
       address: LinkedData.settings.smtp_host,
@@ -171,7 +174,7 @@ class TestNotifications < LinkedData::TestCase
     assert_equal options, expected_options
 
     # testing SMTP authentification-based login
-    current_auth_type = LinkedData.settings.smtp_auth_type
+
     LinkedData.settings.smtp_auth_type = :plain
     options = LinkedData::Utils::Notifier.mail_options
     expected_options = {


### PR DESCRIPTION
### Require 
* https://github.com/ncbo/goo/pull/150
* https://github.com/ncbo/goo/pull/154

### Context
This PR, implements mostly two things:
* Display values in multiple languages, using a global variable `requested_lang `,  see details and example here: https://github.com/ontoportal-lirmm/goo/pull/32
* Search values in multiple languages, see details here: https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/94, an **update of the SOLR schema.xml file is required.**

See the added [units tests](https://github.com/ncbo/ontologies_linked_data/pull/199/commits/fc48343ad7a3f1867821c173be900cf16506b4b7), for examples.
### Changes 
* Add the serialize_defaults if attributes to load set to `:all ` and some code cleaning (see details in https://github.com/ncbo/ontologies_linked_data/pull/145 )(https://github.com/ncbo/ontologies_linked_data/pull/199/commits/37f74d30f30aa903922ddffee463c4272bb48e80) 
* When archiving a submission delete old files and zip master file if large size  (https://github.com/ncbo/ontologies_linked_data/pull/199/commits/b6134ff85181b12bfcdf20e30cb63f815550f159)
* Refactor tests to be faster by doing the indexation step only if needed (from 15min to 9min) (https://github.com/ncbo/ontologies_linked_data/pull/199/commits/4304cc46ed1cf4126f656069df712595d3e077cb)
* Display the language tags when serializing the results to JSON (https://github.com/ncbo/ontologies_linked_data/pull/199/commits/36a5b68c38a02e0b221ba7b7bfc1169dc14ea01f)
* Update the term index step to include all languages **[Require solr schema update]**(https://github.com/ncbo/ontologies_linked_data/pull/199/commits/ccf753f924c10884267e8578bb1e4ecde53163f6)
* Add multilingual support unit tests (https://github.com/ncbo/ontologies_linked_data/pull/199/commits/fc48343ad7a3f1867821c173be900cf16506b4b7)
