### PR TITLE
Augment the User model with GitHub ID and ORCID iD

### DIFF
--- a/lib/ontologies_linked_data/models/users/user.rb
+++ b/lib/ontologies_linked_data/models/users/user.rb
@@ -18,6 +18,8 @@ module LinkedData
       attribute :role, enforce: [:role, :list], :default => lambda {|x| [LinkedData::Models::Users::Role.default]}
       attribute :firstName
       attribute :lastName
+      attribute :githubId, enforce: [:unique]
+      attribute :orcidId, enforce: [:unique]
       attribute :created, enforce: [:date_time], :default => lambda { |record| DateTime.now }
       attribute :passwordHash, enforce: [:existence]
       attribute :apikey, enforce: [:unique], :default => lambda {|x| SecureRandom.uuid}


### PR DESCRIPTION
This pull request adds `githubId` and `orcidId` attributes to the `User` model, enabling users to associate their GitHub and ORCID iDs. Resolves #160.