### PR TITLE
Chore/docker gemspec improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,43 @@
 ARG RUBY_VERSION=3.1
-ARG DISTRO_NAME=bullseye
+ARG DISTRO=slim-bullseye
 
-FROM ruby:$RUBY_VERSION-$DISTRO_NAME
+FROM ruby:$RUBY_VERSION-$DISTRO
 
-RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  openjdk-11-jre-headless \
-  raptor2-utils \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    libxml2 \
+    libxslt-dev \
+    openjdk-11-jre-headless \
+    raptor2-utils \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /srv/ontoportal/ontologies_linked_data
-RUN mkdir -p /srv/ontoportal/bundle
-COPY Gemfile* /srv/ontoportal/ontologies_linked_data/
+WORKDIR /app
 
-WORKDIR /srv/ontoportal/ontologies_linked_data
+# Use a dedicated bundle path
+ENV BUNDLE_PATH=/bundle
+ENV GEM_HOME=/bundle
+ENV PATH="$BUNDLE_PATH/bin:$PATH"
+
+COPY Gemfile* *.gemspec ./
+
+# Copy only the `version.rb` file to prevent missing file errors!
+COPY lib/ontologies_linked_data/version.rb lib/ontologies_linked_data/
 
 RUN gem update --system
-RUN gem install bundler
-ENV BUNDLE_PATH=/srv/ontoportal/bundle
-RUN bundle install
 
-COPY . /srv/ontoportal/ontologies_linked_data
+#I nstall the exact Bundler version from Gemfile.lock (if it exists)
+RUN if [ -f Gemfile.lock ]; then \
+      BUNDLER_VERSION=$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1 | tr -d ' '); \
+      gem install bundler -v "$BUNDLER_VERSION"; \
+    else \
+      gem install bundler; \
+    fi
+
+RUN bundle config set --local path '/bundle'
+RUN bundle config set --global no-document 'true'
+RUN bundle install --jobs 4 --retry 3
+
+COPY . ./
+
+CMD ["bundle", "exec", "rake"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG RUBY_VERSION=3.1
-ARG DISTRO=slim-bullseye
+ARG DISTRO=bullseye
 
 FROM ruby:$RUBY_VERSION-$DISTRO
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gemspec
+
 gem 'activesupport', '~> 4'
 gem 'addressable', '~> 2.8'
 gem 'bcrypt', '~> 3.0'
@@ -37,6 +39,5 @@ end
 gem 'goo', github: 'ncbo/goo', branch: 'master'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'master'
 
-gem 'net-ftp'
 gem 'public_suffix', '~> 5.1.1'
 gem 'net-imap', '~> 0.4.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: 39f67ab7fae7675b6ff417ace0ab923e40ffcbcd
+  revision: b9019ad9e1eb78c74105fc6c6a879085066da17d
   branch: master
   specs:
     goo (0.0.2)
@@ -23,6 +23,25 @@ GIT
       json_pure (>= 1.4)
       net-http-persistent (= 2.9.4)
       rdf (>= 1.0)
+
+PATH
+  remote: .
+  specs:
+    ontologies_linked_data (0.0.1)
+      activesupport
+      bcrypt
+      goo
+      json
+      libxml-ruby
+      multi_json
+      net-ftp
+      oj
+      omni_logger
+      pony
+      rack
+      rack-test
+      rsolr
+      rubyzip
 
 GEM
   remote: https://rubygems.org/
@@ -203,6 +222,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -217,10 +237,10 @@ DEPENDENCIES
   minitest (~> 4)
   minitest-reporters (>= 0.5.0)
   multi_json (~> 1.0)
-  net-ftp
   net-imap (~> 0.4.18)
   oj (~> 3.0)
   omni_logger
+  ontologies_linked_data!
   pony
   pry
   public_suffix (~> 5.1.1)
@@ -238,4 +258,4 @@ DEPENDENCIES
   thin
 
 BUNDLED WITH
-   2.5.11
+   2.5.20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,12 @@ x-app: &app
       args:
         RUBY_VERSION: '3.1'
     # Increase the version number in the image tag every time Dockerfile or its arguments is changed
-    image: ontologies_ld-dev:0.0.4
+    image: ontologies_ld1-dev:0.0.4
     environment: &env
       # default bundle config resolves to /usr/local/bundle/config inside of the container
       # we are setting it to local app directory if we need to use 'bundle config local'
-      BUNDLE_APP_CONFIG: /srv/ontoportal/ontologies_api/.bundle
-      BUNDLE_PATH: /srv/ontoportal/bundle
+      BUNDLE_APP_CONFIG: /.bundle
+      BUNDLE_PATH: /bundle
       COVERAGE: 'true' # enable simplecov code coverage
       REDIS_HOST: redis-ut
       REDIS_PORT: 6379
@@ -20,8 +20,8 @@ x-app: &app
     command: /bin/bash
     volumes:
       # bundle volume for hosting gems installed by bundle; it speeds up gem install in local development
-      - bundle:/srv/ontoportal/bundle
-      - .:/srv/ontoportal/ontologies_linked_data
+      - bundle:/bundle
+      - .:/app
       # mount directory containing development version of the gems if you need to use 'bundle config local'
       #- /Users/alexskr/ontoportal:/Users/alexskr/ontoportal
     depends_on: &depends_on

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-app: &app
       args:
         RUBY_VERSION: '3.1'
     # Increase the version number in the image tag every time Dockerfile or its arguments is changed
-    image: ontologies_ld1-dev:0.0.4
+    image: ontologies_ld-dev:0.0.4
     environment: &env
       # default bundle config resolves to /usr/local/bundle/config inside of the container
       # we are setting it to local app directory if we need to use 'bundle config local'

--- a/ontologies_linked_data.gemspec
+++ b/ontologies_linked_data.gemspec
@@ -1,33 +1,37 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/ontologies_linked_data/version', __FILE__)
+require_relative 'lib/ontologies_linked_data/version'
 
 Gem::Specification.new do |gem|
+  gem.name          = "ontologies_linked_data"
+  gem.version       = LinkedData::VERSION
+  gem.summary       = "Models and serializers for ontologies and related artifacts backed by an RDF database"
+  gem.summary       = "This library can be used for interacting with an AllegroGraph or 4store instance that stores " \
+                      "BioPortal-based ontology information. Models in the library are based on Goo. Serializers " \
+                      "support RDF serialization as Rack Middleware and automatic generation of hypermedia links."
   gem.authors       = ["Paul R Alexander"]
-  gem.email         = ["palexander@stanford.edu"]
-  gem.description   = %q{Models and serializers for ontologies and related artifacts backed by 4store}
-  gem.summary       = %q{This library can be used for interacting with a 4store instance that stores NCBO-based ontology information. Models in the library are based on Goo. Serializers support RDF serialization as Rack Middleware and automatic generation of hypermedia links.}
+  gem.email         = ["support@bioontology.org"]
   gem.homepage      = "https://github.com/ncbo/ontologies_linked_data"
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "ontologies_linked_data"
+  gem.files         = %x(git ls-files).split("\n")
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.require_paths = ["lib"]
-  gem.version       = LinkedData::VERSION
 
+  gem.required_ruby_version = ">= 3.1"
+
+  gem.add_dependency("activesupport")
+  gem.add_dependency("bcrypt")
   gem.add_dependency("goo")
   gem.add_dependency("json")
+  gem.add_dependency("libxml-ruby")
   gem.add_dependency("multi_json")
+  gem.add_dependency("net-ftp")
   gem.add_dependency("oj")
-  gem.add_dependency("bcrypt")
+  gem.add_dependency("omni_logger")
+  gem.add_dependency("pony")
   gem.add_dependency("rack")
   gem.add_dependency("rack-test")
-  gem.add_dependency("rubyzip")
-  gem.add_dependency("libxml-ruby")
-  gem.add_dependency("activesupport")
   gem.add_dependency("rsolr")
-  gem.add_dependency("pony")
-  gem.add_dependency("omni_logger")
+  gem.add_dependency("rubyzip")
 
   gem.add_development_dependency("email_spec")
 


### PR DESCRIPTION
Update gemspec for better dependency management:
 - Removed `test_files` as it is deprecated in modern RubyGems
 - updated contact email and description
 - moved net-ftp from Gemfile to gemspec.
  This ensures it is automatically included in projects that depend on this gem.
  Starting from Ruby 3.1, net-ftp is no longer included by default.
  
Generalize Dockerfile and docker-compose setup
simplify paths