### PR TITLE
fix/Ensure Files Copied to Repository Have Group Write Privileges

### DIFF
--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1224,4 +1224,37 @@ eos
     sub.delete
     assert !Dir.exist?(data_folder)
   end
+
+  def test_copy_file_repository_from_tempfile
+    # Simulate a Rack Tempfile upload from tmpdir;
+    # tmpfile get 0600 permission and we need 660 for the copy to repository
+    fixture = "./test/data/ontology_files/BRO_v3.2.owl"
+    tmp     = Tempfile.new(["upload", ".owl"])
+    begin
+      FileUtils.cp(fixture, tmp.path)
+      tmp.close
+
+      # Assert the source Tempfile has default 0600 permissions
+      # `& 0o777` is a bitwise AND that out all non-permission bits
+      # convers 0o100600 (regular file with owner rw) to 0600
+      src_mode = File.stat(tmp.path).mode & 0o0777
+      assert_equal 0o0600, src_mode
+
+      dst = LinkedData::Models::OntologySubmission
+        .copy_file_repository("TMPTEST", 99, tmp.path)
+
+      repo_root = LinkedData.settings.repository_folder
+      assert_match(
+        %r{\A#{Regexp.escape(repo_root)}/TMPTEST/99/},
+        dst,
+        "Expected file to be copied into #{repo_root}/TMPTEST/99/"
+      )
+      assert File.exist?(dst), "Destination file should exist"
+
+      mode = File.stat(dst).mode & 0o0777
+      assert_equal 0o0660, mode, format("Expected file mode 0660, got %o", mode)
+    ensure
+      tmp.unlink
+    end
+  end
 end


### PR DESCRIPTION
When a user uploads via the API, Rack/Tempfile writes files to /tmp with mode `0600` (owner‑only). Our `copy_file_repository` method then copies the file into the repository but **preserves** those original permissions, ignoring the UMask we set.

This patch forces any file copied into our repository to mode `0660`, granting read/write access to the service group.

It also creates (or re‑chmods) the target directory with mode `2770` (group‑writable + set‑GID), ensuring that future files inherit the correct group.

**Why it matters:**

- Group‑write permission is important for production hardening, where we’ll run API/cron under a dedicated service account separate from the deployer/ops user.
- Without this change, files coming from Tempfile aren’t accessible by the deployer/ops account, causing permission errors when running ncbo_cron scripts from the command line.


relates to:
- https://github.com/ncbo/bioportal-project/issues/323
- https://github.com/ncbo/virtual_appliance/issues/42
- https://github.com/ncbo/ontologies_linked_data/commit/f32bc171e487b7c87fee28b80d9a411a7d45aa79