### PR TITLE
Improve file copy error handling and post-copy verification in copy_file_repository

### DIFF
--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -303,13 +303,18 @@ module LinkedData
           # repository files are also accessible by the service group as intended,
           # we explicitly chmod the destination file to REPOSITORY_FILE_MODE.
           FileUtils.chmod(REPOSITORY_FILE_MODE, dst)
-
-          raise "Unable to copy #{src} to #{dst}" unless File.exist?(dst)
-
-          dst
         rescue StandardError => e
-          raise "Failed to copy #{src} to #{dst}: [#{e.class}] #{e.message}"
+          raise e.class, "Failed to copy #{src} to #{dst}: #{e.message}", e.backtrace
         end
+
+        # Sanity check: ensure the file actually exists after copy and chmod
+        # This guards against rare cases like silent file storage failures or
+        # race conditions
+        unless File.exist?(dst)
+          raise IOError, "Copy operation completed without error, but file '#{dst}' does not exist"
+        end
+
+        dst
       end
 
       def valid?


### PR DESCRIPTION
Improve file copy error handling and post-copy verification in copy_file_repository

- Replace shallow raise that discarded original exception type and backtrace with raise using e.class, custom message, and e.backtrace
- Move File.exist? check outside of begin-rescue to avoid catching assertion errors unrelated to mkdir, chmod, or copy
- Raise IOError for missing post-copy file to clarify semantics


follow up to https://github.com/ncbo/ontologies_linked_data/pull/240