### PR TITLE
Add Cloudflare Analytics notification and refactor template rendering

### DIFF
--- a/lib/ontologies_linked_data/config/config.rb
+++ b/lib/ontologies_linked_data/config/config.rb
@@ -31,7 +31,7 @@ module LinkedData
     # Java/JVM options
     @settings.java_max_heap_size            ||= '10240M'
 
-    @settings.ui_name                       ||= 'Bioportal'
+    @settings.ui_name                       ||= 'BioPortal'
     @settings.ui_host                       ||= 'bioportal.bioontology.org'
     @settings.replace_url_prefix            ||= false
     @settings.id_url_prefix                 ||= "http://data.bioontology.org/"

--- a/lib/ontologies_linked_data/utils/notifications.rb
+++ b/lib/ontologies_linked_data/utils/notifications.rb
@@ -117,6 +117,17 @@ module LinkedData
         Notifier.notify_mails_grouped(subject, body, recipients)
       end
 
+      def self.cloudflare_analytics(result_data)
+        ui_name = LinkedData.settings.ui_name
+        subject = "[#{ui_name}] Cloudflare Analytics daily collection result: #{result_data[:status]}"
+        recipients = Notifier.ontoportal_admin_emails
+        body = render_template('cloudflare_analytics.erb', {
+          result_data: result_data
+        })
+
+        Notifier.notify_mails_grouped(subject, body, recipients)
+      end
+
       def self.render_template(template_name, locals = {})
         # template_path = File.join(File.dirname(__FILE__), '..', '..', 'views', template_name)
         gem_path = Gem.loaded_specs['ontologies_linked_data'].full_gem_path

--- a/lib/ontologies_linked_data/utils/notifications.rb
+++ b/lib/ontologies_linked_data/utils/notifications.rb
@@ -128,8 +128,9 @@ module LinkedData
         Notifier.notify_mails_grouped(subject, body, recipients)
       end
 
+      private
+
       def self.render_template(template_name, locals = {})
-        # template_path = File.join(File.dirname(__FILE__), '..', '..', 'views', template_name)
         gem_path = Gem.loaded_specs['ontologies_linked_data'].full_gem_path
         template_path = File.join(gem_path, 'views', 'emails', template_name)
         template = File.read(template_path)

--- a/lib/ontologies_linked_data/utils/notifications.rb
+++ b/lib/ontologies_linked_data/utils/notifications.rb
@@ -106,16 +106,29 @@ module LinkedData
 
       def self.obofoundry_sync(missing_onts, obsolete_onts)
         ui_name = LinkedData.settings.ui_name
+        subject = "[#{ui_name}] OBO Foundry synchronization report"
+        recipients = Notifier.ontoportal_admin_emails
+        body = render_template('obofoundry_sync.erb', {
+          ui_name: ui_name,
+          missing_onts: missing_onts,
+          obsolete_onts: obsolete_onts,
+        })
+
+        Notifier.notify_mails_grouped(subject, body, recipients)
+      end
+
+      def self.render_template(template_name, locals = {})
+        # template_path = File.join(File.dirname(__FILE__), '..', '..', 'views', template_name)
         gem_path = Gem.loaded_specs['ontologies_linked_data'].full_gem_path
-        template = File.read(File.join(gem_path, 'views/emails/obofoundry_sync.erb'))
+        template_path = File.join(gem_path, 'views', 'emails', template_name)
+        template = File.read(template_path)
 
         b = binding
-        b.local_variable_set(:ui_name, ui_name)
-        b.local_variable_set(:missing_onts, missing_onts)
-        b.local_variable_set(:obsolete_onts, obsolete_onts)
-        body = ERB.new(template).result(b)
+        locals.each { |k, v| b.local_variable_set(k, v) }
 
-        Notifier.notify_ontoportal_admins("[#{ui_name}] OBO Foundry synchronization report", body)
+        ERB.new(template).result(b)
+      rescue Errno::ENOENT => e
+        raise "Template not found: #{template_path}"
       end
 
       NEW_NOTE = <<EOS

--- a/test/util/test_notifications.rb
+++ b/test/util/test_notifications.rb
@@ -1,8 +1,7 @@
-require_relative "../test_case"
+require_relative '../test_case'
 
-require "email_spec"
-require "logger"
-
+require 'email_spec'
+require 'logger'
 
 class TestNotifications < LinkedData::TestCase
   include EmailSpec::Helpers
@@ -12,7 +11,7 @@ class TestNotifications < LinkedData::TestCase
     @@disable_override = LinkedData.settings.email_disable_override
     @@old_support_mails = LinkedData.settings.ontoportal_admin_emails
     if @@old_support_mails.nil? || @@old_support_mails.empty?
-      LinkedData.settings.ontoportal_admin_emails = ["ontoportal-support@mail.com"]
+      LinkedData.settings.ontoportal_admin_emails = ['ontoportal-support@mail.com']
     end
     LinkedData.settings.email_disable_override = true
     LinkedData.settings.enable_notifications = true
@@ -21,7 +20,7 @@ class TestNotifications < LinkedData::TestCase
     @@ont = LinkedData::SampleData::Ontology.create_ontologies_and_submissions(ont_count: 1, submission_count: 1)[2].first
     @@ont.bring_remaining
     @@user = @@ont.administeredBy.first
-    @@subscription = self.new("before_suite")._subscription(@@ont)
+    @@subscription = new('before_suite')._subscription(@@ont)
     @@user.bring_remaining
     @@user.subscription = [@@subscription]
     @@user.save
@@ -44,14 +43,14 @@ class TestNotifications < LinkedData::TestCase
   def _subscription(ont)
     subscription = LinkedData::Models::Users::Subscription.new
     subscription.ontology = ont
-    subscription.notification_type = LinkedData::Models::Users::NotificationType.find("ALL").first
+    subscription.notification_type = LinkedData::Models::Users::NotificationType.find('ALL').first
     subscription.save
   end
 
   def test_send_notification
-    recipients = ["test@example.org"]
-    subject = "Test subject"
-    body = "My test body"
+    recipients = ['test@example.org']
+    subject = 'Test subject'
+    body = 'My test body'
 
     # Email recipient address will be overridden
     LinkedData.settings.email_disable_override = false
@@ -60,11 +59,7 @@ class TestNotifications < LinkedData::TestCase
 
     # Disable override
     LinkedData.settings.email_disable_override = true
-    LinkedData::Utils::Notifier.notify({
-                                              recipients: recipients,
-                                              subject: subject,
-                                              body: body
-                                            })
+    LinkedData::Utils::Notifier.notify({ recipients: recipients, subject: subject, body: body })
     assert_equal recipients, last_email_sent.to
     assert_equal [LinkedData.settings.email_sender], last_email_sent.from
     assert_equal last_email_sent.body.raw_source, body
@@ -72,9 +67,9 @@ class TestNotifications < LinkedData::TestCase
   end
 
   def test_new_note_notification
-    recipients = ["test@example.org"]
-    subject = "Test note subject"
-    body = "Test note body"
+    recipients = ['test@example.org']
+    subject = 'Test note subject'
+    body = 'Test note body'
     note = LinkedData::Models::Note.new
     note.creator = @@user
     note.subject = subject
@@ -84,11 +79,11 @@ class TestNotifications < LinkedData::TestCase
     assert_match "[#{@@ui_name} Notes]", last_email_sent.subject
     assert_equal [@@user.email], last_email_sent.to
   ensure
-    note.delete if note
+    note&.delete
   end
 
   def test_processing_complete_notification
-    options = { ont_count: 1, submission_count: 2, acronym: "NOTIFY" }
+    options = { ont_count: 1, submission_count: 2, acronym: 'NOTIFY' }
     ont = LinkedData::SampleData::Ontology.create_ontologies_and_submissions(options)[2].first
     subscription = _subscription(ont)
     @@user.subscription = @@user.subscription.dup << subscription
@@ -101,27 +96,26 @@ class TestNotifications < LinkedData::TestCase
 
     first_user = subscription.user.first
     first_user.bring :email
-    assert_match "Parsing Success", all_emails.first.subject
+    assert_match 'Parsing Success', all_emails.first.subject
     assert_equal [first_user.email], all_emails.first.to
 
-    assert_match ("Parsing Success"), all_emails.last.subject
+    assert_match 'Parsing Success', all_emails.last.subject
     assert_equal @@support_mails.uniq.sort, all_emails[1].to.sort
     assert_equal admin_mails.uniq.sort, all_emails.last.to.sort
 
-
     reset_mailer
-    sub = ont.submissions.sort_by { |s| s.id}.first
-    sub.process_submission(Logger.new(TestLogFile.new), {archive: true})
+    sub = ont.submissions.sort_by { |s| s.id }.first
+    sub.process_submission(Logger.new(TestLogFile.new), { archive: true })
 
     assert_empty all_emails
   ensure
-    ont.delete if ont
-    subscription.delete if subscription
+    ont&.delete
+    subscription&.delete
   end
 
   def test_disable_administrative_notifications
     LinkedData.settings.enable_administrative_notifications = false
-    options = { ont_count: 1, submission_count: 1, acronym: "DONTNOTIFY" }
+    options = { ont_count: 1, submission_count: 1, acronym: 'DONTNOTIFY' }
     ont = LinkedData::SampleData::Ontology.create_ontologies_and_submissions(options)[2].first
     ont.latest_submission(status: :any).process_submission(Logger.new(TestLogFile.new))
     admin_mails = LinkedData::Utils::Notifier.ontology_admin_emails(ont)
@@ -129,22 +123,25 @@ class TestNotifications < LinkedData::TestCase
 
     refute_match @@support_mails, last_email_sent.to.sort
     assert_equal admin_mails, last_email_sent.to.sort
-    assert_match ("Parsing Success"), all_emails.last.subject
+    assert_match 'Parsing Success', all_emails.last.subject
     LinkedData.settings.enable_administrative_notifications = true
   ensure
-    ont.delete if ont
+    ont&.delete
   end
 
   def test_remote_ontology_pull_notification
-    recipients = ["test@example.org"]
-    ont_count, acronyms, ontologies = LinkedData::SampleData::Ontology.create_ontologies_and_submissions(ont_count: 1, submission_count: 1, process_submission: false)
+    recipients = ['test@example.org']
+    _ont_count, _acronyms, ontologies = LinkedData::SampleData::Ontology.create_ontologies_and_submissions(
+      ont_count: 1, submission_count: 1, process_submission: false
+    )
 
-    ont = LinkedData::Models::Ontology.find(ontologies[0].id).include(:acronym, :administeredBy, :name, :submissions).first
+    ont = LinkedData::Models::Ontology.find(ontologies[0].id)
+                                      .include(:acronym, :administeredBy, :name, :submissions).first
     ont_admins = Array.new(3) { LinkedData::Models::User.new }
     ont_admins.each_with_index do |user, i|
       user.username = "Test User #{i}"
       user.email = "tester_#{i}@example.org"
-      user.password = "password"
+      user.password = 'password'
       user.save
       assert user.valid?, user.errors
     end
@@ -164,7 +161,7 @@ class TestNotifications < LinkedData::TestCase
     assert_equal admin_mails, last_email_sent.to.sort
   ensure
     ont_admins.each do |user|
-      user.delete if user
+      user&.delete
     end
   end
 

--- a/test/util/test_notifications.rb
+++ b/test/util/test_notifications.rb
@@ -166,6 +166,43 @@ class TestNotifications < LinkedData::TestCase
     end
   end
 
+  def test_cloudflare_analytics_success_notification
+    start_time = Time.now - 3600
+    end_time = Time.now
+    result_data = {
+      start_time: start_time,
+      end_time: end_time,
+      duration: 3600,
+      status: 'success',
+      error: nil
+    }
+
+    LinkedData::Utils::Notifications.cloudflare_analytics(result_data)
+
+    assert_equal 1, all_emails.size
+    assert_match 'success', last_email_sent.subject
+    assert_includes last_email_sent.body.raw_source, 'completed successfully'
+    assert_includes last_email_sent.body.raw_source, start_time.to_s
+  end
+
+  def test_cloudflare_analytics_failure_notification
+    start_time = Time.now - 3600
+    end_time = Time.now
+    result_data = {
+      start_time: start_time,
+      end_time: end_time,
+      duration: 3600,
+      status: 'error',
+      error: 'Connection timeout'
+    }
+
+    LinkedData::Utils::Notifications.cloudflare_analytics(result_data)
+
+    assert_equal 1, all_emails.size
+    assert_match 'error', last_email_sent.subject
+    assert_includes last_email_sent.body.raw_source, 'Connection timeout'
+  end
+
   def test_render_template
     gem_path = "/fake/gem/path"
     Gem.loaded_specs.stubs(:[]).with('ontologies_linked_data').returns(

--- a/test/util/test_notifications.rb
+++ b/test/util/test_notifications.rb
@@ -18,7 +18,8 @@ class TestNotifications < LinkedData::TestCase
     LinkedData.settings.enable_notifications = true
     @@ui_name = LinkedData.settings.ui_name
     @@support_mails = LinkedData.settings.ontoportal_admin_emails
-    @@ont = LinkedData::SampleData::Ontology.create_ontologies_and_submissions(ont_count: 1, submission_count: 1)[2].first
+    @@ont = LinkedData::SampleData::Ontology.create_ontologies_and_submissions(ont_count: 1, 
+                                                                               submission_count: 1)[2].first
     @@ont.bring_remaining
     @@user = @@ont.administeredBy.first
     @@subscription = new('before_suite')._subscription(@@ont)
@@ -204,27 +205,27 @@ class TestNotifications < LinkedData::TestCase
   end
 
   def test_render_template
-    gem_path = "/fake/gem/path"
+    gem_path = '/fake/gem/path'
     Gem.loaded_specs.stubs(:[]).with('ontologies_linked_data').returns(
       stub(full_gem_path: gem_path)
     )
 
-    template_content = "Hello <%= name %>!"
+    template_content = 'Hello <%= name %>!'
     File.expects(:read).with("#{gem_path}/views/emails/test.erb").returns(template_content)
 
     result = LinkedData::Utils::Notifications.render_template('test.erb', { name: 'World' })
-    assert_equal "Hello World!", result
+    assert_equal 'Hello World!', result
   end
 
   def test_render_template_file_not_found
-    gem_path = "/fake/gem/path"
+    gem_path = '/fake/gem/path'
     Gem.loaded_specs.stubs(:[]).with('ontologies_linked_data').returns(
       stub(full_gem_path: gem_path)
     )
 
     File.expects(:read).raises(Errno::ENOENT)
 
-    assert_raises(RuntimeError, "Template not found") do
+    assert_raises(RuntimeError, 'Template not found') do
       LinkedData::Utils::Notifications.render_template('nonexistent.erb', {})
     end
   end

--- a/views/emails/cloudflare_analytics.erb
+++ b/views/emails/cloudflare_analytics.erb
@@ -1,0 +1,16 @@
+<% if result_data[:status] == 'success' %>
+  Cloudflare Analytics job completed successfully<br><br>
+
+  Start time: <%= result_data[:start_time].utc %><br>
+  End time: <%= result_data[:end_time].utc %><br>
+  Duration: <%= result_data[:duration] %> seconds<br><br>
+<% else %>
+  <span style="font-weight: bold; color: red;">Cloudflare Analytics job failed!</span><br><br>
+
+  Start time: <%= result_data[:start_time].utc %><br>
+  End time: <%= result_data[:end_time].utc %><br>
+  Duration: <%= result_data[:duration] %> seconds<br><br>
+
+  Error:
+  <pre><%= result_data[:error] %></pre><br><br>
+<% end %>


### PR DESCRIPTION
- Added a notification for sysadmins on daily Cloudflare Analytics job status
- Refactored ERB template loading and rendering into a private `render_template` method to improve code reusability
- Added unit tests for both the `render_template` method and the Cloudflare Analytics notification logic
- Improved setup and teardown logic in the notification unit tests for better maintainability
- Corrected a capitalization issue in the default value of the UI name
- Fixed miscellaneous RuboCop warnings