### PR TITLE
Feature: submission version validation and fixes to the metadata auto-extraction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development do
   gem 'rubocop', require: false
 end
 # NCBO gems (can be from a local dev path or from rubygems/git)
-gem 'goo', github: 'ncbo/goo', branch: 'master'
+gem 'goo', github: 'ncbo/goo', branch: 'develop'
 gem 'sparql-client', github: 'ncbo/sparql-client', tag: 'v6.3.0'
 
 gem 'public_suffix', '~> 5.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: 26c0a69e67ac59778a46caf51202ebd38ccac767
-  branch: master
+  revision: 87a21a76bc61392d0629a19c8a18593f606b52e5
+  branch: develop
   specs:
     goo (0.0.2)
       addressable (~> 2.8)

--- a/config/schemes/ontology_submission.yml
+++ b/config/schemes/ontology_submission.yml
@@ -56,7 +56,7 @@ version:
     "PAV: The version number of a resource.",
     "DOAP: A project release",
     "SCHEMA: The version of the CreativeWork embodied by a specified resource."]
-  extractedMetadata: false
+  extractedMetadata: true
   metadataMappings: [ "omv:version", "mod:version", "owl:versionInfo", "pav:version", "doap:release", "schema:version", "oboInOwl:data-version", "oboInOwl:version" ]
 
 #Status

--- a/lib/ontologies_linked_data/concerns/ontology_submissions/submission_metadata_extractor.rb
+++ b/lib/ontologies_linked_data/concerns/ontology_submissions/submission_metadata_extractor.rb
@@ -5,42 +5,63 @@ module LinkedData
 
         def extract_metadata(logger = nil, heavy_extraction = true, user_params = nil)
           logger ||= Logger.new(STDOUT)
-          logger.info('Extracting metadata from the ontology submission.')
+          logger.info("Extracting metadata from the ontology submission #{self.id}")
+
+          unless self.valid?
+            logger.error("Cannot extract metadata from #{self.id} because the submission is invalid")
+            return
+          end
 
           @submission = self
-          version_info = extract_version
           ontology_iri = extract_ontology_iri
-          @submission.version = version_info if version_info
-          @submission.uri = ontology_iri if ontology_iri
-          @submission.save
+
+          if ontology_iri
+            old_uri = @submission.uri
+            @submission.uri = ontology_iri
+
+            if @submission.valid?
+              @submission.save
+            else
+              logger.error("The extracted submission URI #{ontology_iri} is invalid. Discarding...")
+              @submission.uri = old_uri
+            end
+          end
 
           if heavy_extraction
             begin
               # Extract metadata directly from the ontology
-              extract_ontology_metadata(logger, user_params, skip_attrs: [:version, :uri])
-              logger.info('Additional metadata extracted.')
+              extract_ontology_metadata(logger, user_params, skip_attrs: [:uri])
+              logger.info('Additional metadata extracted')
             rescue StandardError => e
-              e.backtrace
-              logger.error("Error while extracting additional metadata: #{e}")
+              message = e.message + "\n\n  " + e.backtrace.join("\n  ")
+              logger.error("Error while extracting additional metadata: #{message}")
             end
           end
 
-          if @submission.valid?
-            @submission.save
-          else
-            logger.error("Error while extracting additional metadata: #{@submission.errors}")
-            @submission = LinkedData::Models::OntologySubmission.find(@submission.id).first.bring_remaining
+          version_exists = @submission.version
+
+          if version_exists.to_s.strip.empty?
+            version_info = extract_version
+
+            if version_info
+              @submission.version = version_info
+
+              unless @submission.valid?
+                logger.error("The extracted submission version \"#{version_info}\" is invalid. Discarding...")
+                @submission.version = nil
+              end
+            end
           end
+
+          @submission.save
         end
 
         def extract_version
-
           query = Goo.sparql_query_client.select(:versionInfo).distinct
                      .from(@submission.id)
                      .where([RDF::URI.new('http://bioportal.bioontology.org/ontologies/versionSubject'),
-                             RDF::URI.new('http://www.w3.org/2002/07/owl#versionInfo'),
+                             RDF::URI.new("#{Goo.namespaces[:owl].to_s}versionInfo"),
                              :versionInfo])
-
           sol = query.each_solution.first || {}
           sol[:versionInfo]&.to_s
         end
@@ -49,8 +70,8 @@ module LinkedData
           query = Goo.sparql_query_client.select(:uri).distinct
                      .from(@submission.id)
                      .where([:uri,
-                             RDF::URI.new('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
-                             RDF::URI.new('http://www.w3.org/2002/07/owl#Ontology')])
+                             RDF::URI.new("#{Goo.namespaces[:rdf].to_s}type"),
+                             RDF::URI.new("#{Goo.namespaces[:owl].to_s}Ontology")])
           sol = query.each_solution.first || {}
           RDF::URI.new(sol[:uri]) if sol[:uri]
         end
@@ -58,9 +79,11 @@ module LinkedData
         # Extract additional metadata about the ontology
         # First it extracts the main metadata, then the mapped metadata
         def extract_ontology_metadata(logger, user_params, skip_attrs: [])
+          # The commented out line below would give priority to the existing values over extracted values
+          # user_params = object_to_hash(@submission) unless user_params
           user_params = {} if user_params.nil? || !user_params
           ontology_uri = @submission.uri
-          logger.info("Extraction metadata from ontology #{ontology_uri}")
+          logger.info("Extracting additional metadata from ontology #{ontology_uri}")
 
           # go through all OntologySubmission attributes. Returns symbols
           LinkedData::Models::OntologySubmission.attributes(:all).each do |attr|
@@ -68,9 +91,11 @@ module LinkedData
             # for attribute with the :extractedMetadata setting on, and that have not been defined by the user
             attr_settings = LinkedData::Models::OntologySubmission.attribute_settings(attr)
 
-            attr_not_excluded = user_params && !(user_params.key?(attr) && !user_params[attr].nil? && !user_params[attr].empty?)
-
-            next unless attr_settings[:extractedMetadata] && attr_not_excluded
+            # Check if the user provided a non-empty value for this attribute and override_attrs is not set for this attribute
+            user_provided_value = user_params.key?(attr) && !empty_value?(user_params[attr])
+            # Proceed only if the attribute is marked as extractable and the user did NOT provide a value
+            should_extract = attr_settings[:extractedMetadata] && !user_provided_value
+            next unless should_extract
 
             # a boolean to check if a value that should be single have already been extracted
             single_extracted = false
@@ -95,7 +120,18 @@ module LinkedData
 
             new_value = value(attr, type)
 
-            send_value(attr, old_value, logger) if empty_value?(new_value) && !empty_value?(old_value)
+            if empty_value?(new_value) && !empty_value?(old_value)
+              logger.error("Extracted attribute #{attr} with the value #{new_value} is empty. Returning to the old value: #{old_value}.")
+              send_value(attr, old_value, logger)
+            end
+          end
+        end
+
+        def object_to_hash(obj)
+          obj.instance_variables.each_with_object({}) do |ivar, hash|
+            key = ivar.to_s.delete("@").to_sym
+            value = obj.instance_variable_get(ivar)
+            hash[key] = value
           end
         end
 
@@ -130,11 +166,10 @@ module LinkedData
 
             @submission.send("#{attr}=", (metadata_values + new_values).uniq.join(', '))
           else
-            new_value = new_value.values.first
-
+            new_value = new_value.is_a?(Hash)? new_value.values.first : new_value.to_s
             new_value = find_or_create_agent(attr, nil, logger) if enforce?(attr, :Agent)
-
             @submission.send("#{attr}=", new_value)
+            old_val = @submission.previous_values&.key?(attr) ? @submission.previous_values[attr] : nil
             single_extracted = true
           end
 
@@ -160,14 +195,14 @@ module LinkedData
                 case metadata_literal.language
                 when :en, :eng
                   # Take the value with english language over other languages
-                  hash[metadata_uri] = metadata_literal
+                  hash[metadata_uri] = metadata_literal.to_s
                   return hash
                 when :fr, :fre
                   # If no english, take french
                   if hash[metadata_uri].language == :en || hash[metadata_uri].language == :eng
                     return hash
                   else
-                    hash[metadata_uri] = metadata_literal
+                    hash[metadata_uri] = metadata_literal.to_s
                     return hash
                   end
                 else
@@ -176,11 +211,11 @@ module LinkedData
               end
             else
               # Take the value with no language in priority (considered as a default)
-              hash[metadata_uri] = metadata_literal
+              hash[metadata_uri] = metadata_literal.to_s
               return hash
             end
           else
-            hash[metadata_uri] = metadata_literal
+            hash[metadata_uri] = metadata_literal.to_s
             hash
           end
         end

--- a/lib/ontologies_linked_data/concerns/ontology_submissions/submission_metadata_extractor.rb
+++ b/lib/ontologies_linked_data/concerns/ontology_submissions/submission_metadata_extractor.rb
@@ -91,7 +91,7 @@ module LinkedData
             # for attribute with the :extractedMetadata setting on, and that have not been defined by the user
             attr_settings = LinkedData::Models::OntologySubmission.attribute_settings(attr)
 
-            # Check if the user provided a non-empty value for this attribute and override_attrs is not set for this attribute
+            # Check if the user provided a non-empty value for this attribute
             user_provided_value = user_params.key?(attr) && !empty_value?(user_params[attr])
             # Proceed only if the attribute is marked as extractable and the user did NOT provide a value
             should_extract = attr_settings[:extractedMetadata] && !user_provided_value

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -46,7 +46,7 @@ module LinkedData
       # Ontology metadata
       # General metadata
       attribute :versionIRI, namespace: :owl, type: :uri, enforce: [:distinct_of_uri]
-      attribute :version, namespace: :omv
+      attribute :version, namespace: :omv, enforce: [:safe_text_64]
       attribute :status, namespace: :omv, default: ->(x) { 'production' }
       attribute :deprecated, namespace: :owl, type: :boolean, default: ->(x) { false }
       attribute :hasOntologyLanguage, namespace: :omv, type: :ontology_format, enforce: [:existence]

--- a/test/models/test_ontology_common.rb
+++ b/test/models/test_ontology_common.rb
@@ -51,7 +51,7 @@ module LinkedData
     #   diff              = false
     #   delete            = true  # delete any existing submissions
     ##############################################
-    def submission_parse(acronym, name, ontologyFile, id, parse_options={})
+    def submission_parse(acronym, name, ontologyFile, id, parse_options={}, set_attributes={})
       return if ENV["SKIP_PARSING"]
       parse_options[:process_rdf].nil? && parse_options[:process_rdf] = true
       parse_options[:index_search].nil? && parse_options[:index_search] = false
@@ -94,6 +94,10 @@ module LinkedData
 
       if masterFileName
         ont_submission.masterFileName = masterFileName
+      end
+
+      set_attributes.each do |attr, val|
+        ont_submission.send("#{attr}=", val) if ont_submission.respond_to?("#{attr}=")
       end
 
       if ont_submission.valid?


### PR DESCRIPTION
1. Adds validation `:safe_text_64` to the `version` attribute of submission
2. Turns on submission version auto-extraction in `ontology_submission.yml` (`extractedMetadata: true`)
3. Fixes several bugs in the metadata auto-extraction process:
    1. If metadata auto-extraction fails and the `@submission` object becomes invalid, the `@submission` global memory space is incorrectly reset, and any changes that happened in the meantime become lost (including `:submissionStatus`) to other modules relying on the `@submission` object:
https://github.com/ncbo/ontologies_linked_data/blob/v6.4.0/lib/ontologies_linked_data/concerns/ontology_submissions/submission_metadata_extractor.rb#L32
    2. In several instances, `@submission.save` was called before checking for `@submission.valid?`. Once the strict `@submission.version` validation had been introduced, this resulted in multiple unhandled runtime errors:
https://github.com/ncbo/ontologies_linked_data/blob/v6.4.0/lib/ontologies_linked_data/concerns/ontology_submissions/submission_metadata_extractor.rb#L15
https://github.com/ncbo/ontologies_linked_data/blob/v6.4.0/lib/ontologies_linked_data/services/submission_process/operations/submission_rdf_generator.rb#L322
https://github.com/ncbo/ontologies_linked_data/blob/v6.4.0/lib/ontologies_linked_data/services/submission_process/operations/submission_rdf_generator.rb#L327
    4. Literal values were handled inconsistently. Depending on the sequence of the code executed (`extract_version` vs `extract_ontology_metadata`), the same attribute may have been assigned the type `String` or the type `RDF::Literal`. For example:
    ```
    { :version => "Version 3.0" }
    # OR
    { :version => #<RDF::Literal:0x2a94(Version 3.0)> }
    ```
    5. An obscure GOO bug (https://github.com/ncbo/ncbo_cron/issues/82#issuecomment-3104054081) was causing `@submission.version` to become nil unexpectedly in certain cases
    6. The attribute `:version` had a custom code written for auto-extraction, which bypassed the main auto-extraction routine (`extract_ontology_metadata`). This custom code used only the `owl:versionInfo` property for extracting the version and did not take into account any other properties specified in the metadata mappings array:
    ```
    metadataMappings: [ "omv:version", "mod:version", "owl:versionInfo", "pav:version", "doap:release", "schema:version", "oboInOwl:data-version", "oboInOwl:version" ]
    ```