### PR TITLE
add url datatype for attributes that should be restricted to HTTP/HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'request_store'
 gem 'rest-client'
 gem 'rsolr'
 gem 'thin', '~> 1.0' # compatibility version pin. thin should be replaced with webmoc
-
+gem "down", "~> 5.0"
 
 # Testing
 group :test do
@@ -37,7 +37,7 @@ group :development do
   gem 'rubocop', require: false
 end
 # NCBO gems (can be from a local dev path or from rubygems/git)
-gem 'goo', github: 'ncbo/goo', branch: 'master'
+gem 'goo', github: 'ncbo/goo', branch: 'develop'
 gem 'sparql-client', github: 'ncbo/sparql-client', tag: 'v6.3.0'
 
 gem 'public_suffix', '~> 5.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: 26c0a69e67ac59778a46caf51202ebd38ccac767
-  branch: master
+  revision: ca5f9d858eef89923903236fe6f76c78271e538d
+  branch: develop
   specs:
     goo (0.0.2)
       addressable (~> 2.8)
@@ -69,6 +69,8 @@ GEM
     date (3.4.1)
     docile (1.4.1)
     domain_name (0.6.20240107)
+    down (5.4.2)
+      addressable (~> 2.8)
     email_spec (2.3.0)
       htmlentities (~> 4.3.3)
       launchy (>= 2.1, < 4.0)
@@ -111,7 +113,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0819)
+    mime-types-data (3.2025.0826)
     mini_mime (1.1.5)
     minitest (4.7.5)
     minitest-reporters (0.14.24)
@@ -199,7 +201,7 @@ GEM
       prism (~> 1.4)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (3.0.1)
+    rubyzip (3.0.2)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -238,6 +240,7 @@ DEPENDENCIES
   addressable (~> 2.8)
   bcrypt (~> 3.0)
   cube-ruby
+  down (~> 5.0)
   email_spec
   ffi
   goo!

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -3,7 +3,7 @@ require 'net/http'
 require 'uri'
 require 'open-uri'
 require 'cgi'
-require 'benchmark'
+# require 'benchmark'
 require 'csv'
 require 'fileutils'
 
@@ -59,12 +59,8 @@ module LinkedData
       # Description metadata
       attribute :description, namespace: :omv, enforce: %i[concatenate], fuzzy_search: true
 
-      # attribute :homepage
-      # attribute :documentation, namespace: :omv
-      # attribute :publication
-      # attribute :uri, namespace: :omv
-      attribute :homepage, namespace: :foaf, type: :uri
-      attribute :documentation, namespace: :omv, type: :uri
+      attribute :homepage, namespace: :foaf, type: :url
+      attribute :documentation, namespace: :omv, type: :url
       attribute :publication, type: %i[uri list]
       attribute :uri, namespace: :omv, type: :uri, enforce: %i[distinct_of_identifier], fuzzy_search: true
 
@@ -124,7 +120,7 @@ module LinkedData
       attribute :wasInvalidatedBy, namespace: :prov, type: :list
 
       # Links
-      attribute :pullLocation, type: :uri # URI for pulling ontology
+      attribute :pullLocation, type: :url # URL for pulling ontology
       attribute :isFormatOf, namespace: :dct, type: :uri
       attribute :hasFormat, namespace: :dct, type: %i[uri list]
       attribute :dataDump, namespace: :void, type: :uri, default: -> (s) { data_dump_default(s) }

--- a/lib/ontologies_linked_data/models/project.rb
+++ b/lib/ontologies_linked_data/models/project.rb
@@ -7,7 +7,7 @@ module LinkedData
       attribute :created, enforce: [:date_time], :default => lambda {|x| DateTime.now }
       attribute :updated, enforce: [:date_time], :default => lambda {|x| DateTime.now }
       attribute :name, enforce: [:existence, :safe_text_256]
-      attribute :homePage, enforce: [:uri, :existence]
+      attribute :homePage, enforce: [:url, :existence]
       attribute :description, enforce: [:existence, :safe_text]
       attribute :contacts, enforce: [:safe_text_256]
       attribute :institution, enforce: [:safe_text_256]


### PR DESCRIPTION
Restrict attributes that are used for rendering links or pulling remote files needs to be restricted to `url`datatype, which limits URIs to HTTP/HTTPS

 `:homepage`, `:documentation`, `:pullLocation`
 
see:
- https://github.com/ncbo/goo/pull/169
- https://github.com/ncbo/goo/issues/164