### PR TITLE
Upgrade owlapi_wrapper JAR to 1.5.1

### DIFF
--- a/lib/ontologies_linked_data/parser/owlapi.rb
+++ b/lib/ontologies_linked_data/parser/owlapi.rb
@@ -13,7 +13,7 @@ module LinkedData
 
     class OWLAPICommand
       def initialize(input_file, output_repo, opts = {})
-        @owlapi_wrapper_jar_path = LinkedData.bindir + "/owlapi-wrapper-1.5.0.jar"
+        @owlapi_wrapper_jar_path = LinkedData.bindir + "/owlapi-wrapper-1.5.1.jar"
         @input_file = input_file
         @output_repo = output_repo
         @master_file = opts[:master_file]


### PR DESCRIPTION
This PR upgrades the `owlapi_wrapper` JAR from `1.5.0` to `1.5.1`. The new version fixes an issue where some ontology classes don't receive either a `notation` or `prefixIRI` annotation during processing. See `owlapi_wrapper` [PR #33](https://github.com/ncbo/owlapi_wrapper/pull/33) for details.

When a class has neither annotation, [`notation_to_class_uri`](https://github.com/ncbo/ontologies_api/blob/dae3e851b8894755a3d4e25c803a6cddfc26974c/helpers/classes_helper.rb#L7) can't resolve it and returns `nil`. As a result, REST requests for those classes may fail with a `400` response, for example:

https://data.bioontology.org/ontologies/EMRO/classes/0000000

with the error:

`"The input class id '0000000' is not a valid IRI".`