### PR TITLE
Chore: disable index_all_data by default during submission processing

### DIFF
--- a/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
+++ b/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
@@ -92,7 +92,7 @@ module LinkedData
       end
 
       def index_all_data?(options)
-        options.empty? || options[:index_all_data].eql?(true)
+        options[:index_all_data].eql?(true)
       end
 
       def index_search?(options)


### PR DESCRIPTION
The AgroPortal-introduced index_all_data feature creates an unbounded number of dynamic Solr fields (one per RDF predicate), which exceeds Solr best practices and triggers warnings when field count exceeds 1000. Disable it by default until a proper redesign can be implemented.