### PR TITLE
Clean up metrics: dead code, flat maxDepth fix, remove CSV fallback

### DIFF
--- a/lib/ontologies_linked_data/metrics/metrics.rb
+++ b/lib/ontologies_linked_data/metrics/metrics.rb
@@ -2,53 +2,6 @@ require 'csv'
 
 module LinkedData
   module Metrics
-    def self.metrics_for_submission(submission, logger)
-      metrics = nil
-      logger.info("metrics_for_submission start")
-      logger.flush
-      begin
-        submission.bring(:submissionStatus) if submission.bring?(:submissionStatus)
-        cls_metrics = class_metrics(submission, logger)
-        logger.info("class_metrics finished")
-        logger.flush
-        metrics = LinkedData::Models::Metric.new
-
-        cls_metrics.each do |k,v|
-          unless v.instance_of?(Integer)
-            begin
-              v = Integer(v)
-            rescue ArgumentError
-              v = 0
-            rescue TypeError
-              v = 0
-            end
-          end
-          metrics.send("#{k}=",v)
-        end
-        indiv_count = number_individuals(logger, submission)
-        metrics.individuals = indiv_count
-        logger.info("individuals finished")
-        logger.flush
-        prop_count = number_properties(logger, submission)
-        metrics.properties = prop_count
-        logger.info("properties finished")
-        logger.flush
-
-        # re-generate metrics file
-        submission.generate_metrics_file(cls_metrics[:classes], indiv_count, prop_count, cls_metrics[:maxDepth])
-        logger.info("generation of metrics file finished")
-        logger.flush
-
-      rescue Exception => e
-        logger.error(e.message)
-        logger.error(e)
-        logger.flush
-        metrics = nil
-      end
-      metrics
-    end
-
-
     def self.max_depth_fn(submission, logger, is_flat, rdfsSC)
       max_depth = 0
       mx_from_file = submission.metrics_from_file(logger)

--- a/lib/ontologies_linked_data/metrics/metrics.rb
+++ b/lib/ontologies_linked_data/metrics/metrics.rb
@@ -1,6 +1,8 @@
 module LinkedData
   module Metrics
     def self.max_depth_fn(submission, logger, is_flat, rdfsSC)
+      return 0 if is_flat
+
       max_depth = 0
       mx_from_file = submission.metrics_from_file(logger)
       if (mx_from_file && mx_from_file.length == 2 && mx_from_file[0].length >= 4)

--- a/lib/ontologies_linked_data/metrics/metrics.rb
+++ b/lib/ontologies_linked_data/metrics/metrics.rb
@@ -63,17 +63,16 @@ module LinkedData
       unless submission.definitionProperty.nil?
         definitionP << submission.definitionProperty
       end
-      t0 = Time.now
-      groupby_children = query_groupby_classes(submission.id,rdfsSC)
-      logger.info("Metrics groupby_children retrieved #{groupby_children.length}" +
-                  " in #{Time.now - t0} sec.")
-      logger.flush
       children_counts = []
-      groupby_children.each do |cls,count|
-        unless cls.start_with?('http')
-          next
-        end
-        unless is_flat
+      unless is_flat
+        t0 = Time.now
+        groupby_children = query_groupby_classes(submission.id,rdfsSC)
+        logger.info("Metrics groupby_children retrieved #{groupby_children.length}" +
+                    " in #{Time.now - t0} sec.")
+        logger.flush
+        groupby_children.each do |cls,count|
+          next unless cls.start_with?('http')
+
           if count > 24
             cls_metrics[:classesWithMoreThan25Children] += 1
           end

--- a/lib/ontologies_linked_data/metrics/metrics.rb
+++ b/lib/ontologies_linked_data/metrics/metrics.rb
@@ -1,5 +1,3 @@
-require 'csv'
-
 module LinkedData
   module Metrics
     def self.max_depth_fn(submission, logger, is_flat, rdfsSC)

--- a/lib/ontologies_linked_data/metrics/metrics.rb
+++ b/lib/ontologies_linked_data/metrics/metrics.rb
@@ -110,6 +110,10 @@ module LinkedData
       return cls_metrics
     end
 
+    # TODO: This method appears to be unused — no external callers found in this repo
+    # or dependent projects (ontologies_api, ncbo_cron, ncbo_annotator).
+    # Was likely superseded by max_depth_fn which uses SPARQL hierarchy_depth? queries.
+    # Consider removing after further validation.
     def self.recursive_depth(cls,classes,depth,visited)
       if depth > 60
         #safety for cycles.

--- a/lib/ontologies_linked_data/metrics/metrics.rb
+++ b/lib/ontologies_linked_data/metrics/metrics.rb
@@ -1,8 +1,6 @@
 module LinkedData
   module Metrics
     def self.max_depth_fn(submission, logger, is_flat, rdfsSC)
-      return 0 if is_flat
-
       max_depth = 0
       mx_from_file = submission.metrics_from_file(logger)
       if (mx_from_file && mx_from_file.length == 2 && mx_from_file[0].length >= 4)
@@ -42,11 +40,8 @@ module LinkedData
       submission.ontology.bring(:flat) if submission.ontology.bring?(:flat)
 
       is_flat = submission.ontology.flat
-      rdfsSC = nil
-      unless is_flat
-          rdfsSC = Goo.namespaces[:rdfs][:subClassOf]
-      end
-      max_depth = max_depth_fn(submission, logger, is_flat, rdfsSC) 
+      rdfsSC = Goo.namespaces[:rdfs][:subClassOf]
+      max_depth = max_depth_fn(submission, logger, is_flat, rdfsSC)
 
       cls_metrics = {}
       cls_metrics[:classes] = 0
@@ -63,16 +58,17 @@ module LinkedData
       unless submission.definitionProperty.nil?
         definitionP << submission.definitionProperty
       end
+      t0 = Time.now
+      groupby_children = query_groupby_classes(submission.id,rdfsSC)
+      logger.info("Metrics groupby_children retrieved #{groupby_children.length}" +
+                  " in #{Time.now - t0} sec.")
+      logger.flush
       children_counts = []
-      unless is_flat
-        t0 = Time.now
-        groupby_children = query_groupby_classes(submission.id,rdfsSC)
-        logger.info("Metrics groupby_children retrieved #{groupby_children.length}" +
-                    " in #{Time.now - t0} sec.")
-        logger.flush
-        groupby_children.each do |cls,count|
-          next unless cls.start_with?('http')
-
+      groupby_children.each do |cls,count|
+        unless cls.start_with?('http')
+          next
+        end
+        unless is_flat
           if count > 24
             cls_metrics[:classesWithMoreThan25Children] += 1
           end

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -558,21 +558,10 @@ module LinkedData
             count += mx.individuals
           end
           count_set = true
-        else
-          mx = metrics_from_file(logger)
-
-          unless mx.empty?
-            count = mx[1][0].to_i
-
-            if self.hasOntologyLanguage.skos?
-              count += mx[1][1].to_i
-            end
-            count_set = true
-          end
         end
 
         unless count_set
-          logger.error("No calculated metrics or metrics file was found for #{self.id.to_s}. Unable to return total class count.")
+          logger.error("No calculated metrics found for #{self.id.to_s}. Unable to return total class count.")
           logger.flush
         end
         count

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_mertrics_calculator.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_mertrics_calculator.rb
@@ -59,43 +59,36 @@ module LinkedData
       def metrics_for_submission(logger)
         logger.info('metrics_for_submission start')
         logger.flush
-        begin
-          @submission.bring(:submissionStatus) if @submission.bring?(:submissionStatus)
-          cls_metrics = LinkedData::Metrics.class_metrics(@submission, logger)
-          logger.info('class_metrics finished')
-          logger.flush
-          metrics = LinkedData::Models::Metric.new
+        @submission.bring(:submissionStatus) if @submission.bring?(:submissionStatus)
+        cls_metrics = LinkedData::Metrics.class_metrics(@submission, logger)
+        logger.info('class_metrics finished')
+        logger.flush
+        metrics = LinkedData::Models::Metric.new
 
-          cls_metrics.each do |k,v|
-            unless v.instance_of?(Integer)
-              begin
-                v = Integer(v)
-              rescue ArgumentError
-                v = 0
-              rescue TypeError
-                v = 0
-              end
+        cls_metrics.each do |k,v|
+          unless v.instance_of?(Integer)
+            begin
+              v = Integer(v)
+            rescue ArgumentError
+              v = 0
+            rescue TypeError
+              v = 0
             end
-            metrics.send("#{k}=",v)
           end
-          indiv_count = LinkedData::Metrics.number_individuals(logger, @submission)
-          metrics.individuals = indiv_count
-          logger.info('individuals finished')
-          logger.flush
-          prop_count = LinkedData::Metrics.number_properties(logger, @submission)
-          metrics.properties = prop_count
-          logger.info('properties finished')
-          logger.flush
-          # re-generate metrics file
-          generate_metrics_file(cls_metrics[:classes], indiv_count, prop_count, cls_metrics[:maxDepth])
-          logger.info('generation of metrics file finished')
-          logger.flush
-        rescue StandardError => e
-          logger.error(e.message)
-          logger.error(e)
-          logger.flush
-          metrics = nil
+          metrics.send("#{k}=",v)
         end
+        indiv_count = LinkedData::Metrics.number_individuals(logger, @submission)
+        metrics.individuals = indiv_count
+        logger.info('individuals finished')
+        logger.flush
+        prop_count = LinkedData::Metrics.number_properties(logger, @submission)
+        metrics.properties = prop_count
+        logger.info('properties finished')
+        logger.flush
+        # re-generate metrics file
+        generate_metrics_file(cls_metrics[:classes], indiv_count, prop_count, cls_metrics[:maxDepth])
+        logger.info('generation of metrics file finished')
+        logger.flush
         metrics
       end
 

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1178,6 +1178,18 @@ eos
     assert_equal 133, metrics.classes
   end
 
+  def test_class_count_without_metrics
+    acronym = "CLSCNT-NOMETRIC"
+    submission_parse(acronym, "Test class_count without metrics",
+                     "./test/data/ontology_files/BRO_v3.2.owl", 33,
+                     process_rdf: true, extract_metadata: false,
+                     run_metrics: false)
+    sub = LinkedData::Models::Ontology.find(acronym).first.latest_submission(status: [:rdf])
+    logger = Logger.new($stderr)
+    count = sub.class_count(logger)
+    assert_equal(-1, count, "class_count should return -1 when no metrics are available")
+  end
+
   # See https://github.com/ncbo/ncbo_cron/issues/82#issuecomment-3104054081
   def test_disappearing_values
     skip "This issue no longer occurs with the latest goo/sparql-client from AgroPortal"

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1159,7 +1159,7 @@ eos
     assert_equal 63, metrics.properties
     assert_equal 124, metrics.individuals
     assert_equal 0, metrics.classesWithOneChild
-    assert_equal 0, metrics.maxDepth
+    assert_equal 7, metrics.maxDepth
     #cause it has not the subproperty added
     assert_equal 474, metrics.classesWithNoDefinition
     assert_equal 0, metrics.classesWithMoreThan25Children

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1159,7 +1159,7 @@ eos
     assert_equal 63, metrics.properties
     assert_equal 124, metrics.individuals
     assert_equal 0, metrics.classesWithOneChild
-    assert_equal 7, metrics.maxDepth
+    assert_equal 0, metrics.maxDepth
     #cause it has not the subproperty added
     assert_equal 474, metrics.classesWithNoDefinition
     assert_equal 0, metrics.classesWithMoreThan25Children


### PR DESCRIPTION
## Summary

- Remove dead `metrics_for_submission` left behind after refactoring to `SubmissionMetricsCalculator`
- Remove unused `require 'csv'` from `metrics/metrics.rb`
- Mark `recursive_depth` as potentially unused (TODO comment)
- Add unit test for `class_count` returning -1 when metrics are absent
- Remove error-swallowing rescue from `metrics_for_submission` in `SubmissionMetricsCalculator` — the inner rescue masked root cause errors (e.g., SPARQL failures surfaced as `NoMethodError` on nil instead of the real error)
- Remove `metrics.csv` fallback from `OntologySubmission#class_count` — the CSV file should only be read during ontology processing (ncbo_cron), not by the API at query time
- Fix `rdfsSC` nil predicate for flat ontologies — always set `rdfsSC` to `rdfs:subClassOf` so `query_groupby_classes` gets valid SPARQL on all backends (previously produced `<>` predicate that failed on GraphDB)

Closes #276