### PR TITLE
Feature: Use alias-backed Solr targets for ontology search indexing (ALT)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development do
   gem 'rubocop', require: false
 end
 # NCBO gems (can be from a local dev path or from rubygems/git)
-gem 'goo', github: 'ncbo/goo', branch: 'development'
+gem 'goo', github: 'ncbo/goo', branch: 'feature/solrcloud-alias-indexing-claude'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'development'
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: fa850f46c94e09b6368ed47728b9cce05b7e9d54
-  branch: development
+  revision: 534648570e056c6da12e12e9f019a14459909dcf
+  branch: feature/solrcloud-alias-indexing-claude
   specs:
     goo (0.0.2)
       addressable (~> 2.8)

--- a/lib/ontologies_linked_data/models/class.rb
+++ b/lib/ontologies_linked_data/models/class.rb
@@ -174,7 +174,7 @@ module LinkedData
         schema_generator.add_dynamic_field('definition_*', 'text_general', indexed: true, stored: true, multi_valued: true)
       end
 
-      enable_indexing(:term_search_core1) do |schema_generator|
+      enable_indexing(:term_search, :main, bootstrap_collection: :term_search_bootstrap) do |schema_generator|
         index_schema(schema_generator)
       end
 

--- a/lib/ontologies_linked_data/models/properties/annotation_property.rb
+++ b/lib/ontologies_linked_data/models/properties/annotation_property.rb
@@ -36,7 +36,7 @@ module LinkedData
               LinkedData::Hypermedia::Link.new("descendants", lambda {|m| "#{self.ontology_link(m)}/properties/#{CGI.escape(m.id.to_s)}/descendants"}, self.uri_type),
               LinkedData::Hypermedia::Link.new("tree", lambda {|m| "#{self.ontology_link(m)}/properties/#{CGI.escape(m.id.to_s)}/tree"}, self.uri_type)
 
-      enable_indexing(:prop_search_core1, :property) do |schema_generator|
+      enable_indexing(:prop_search, :property, bootstrap_collection: :prop_search_bootstrap) do |schema_generator|
         index_schema(schema_generator)
       end
     end

--- a/lib/ontologies_linked_data/models/properties/datatype_property.rb
+++ b/lib/ontologies_linked_data/models/properties/datatype_property.rb
@@ -36,7 +36,7 @@ module LinkedData
               LinkedData::Hypermedia::Link.new("descendants", lambda {|m| "#{self.ontology_link(m)}/properties/#{CGI.escape(m.id.to_s)}/descendants"}, self.uri_type),
               LinkedData::Hypermedia::Link.new("tree", lambda {|m| "#{self.ontology_link(m)}/properties/#{CGI.escape(m.id.to_s)}/tree"}, self.uri_type)
 
-      enable_indexing(:prop_search_core1, :property) do |schema_generator|
+      enable_indexing(:prop_search, :property, bootstrap_collection: :prop_search_bootstrap) do |schema_generator|
         index_schema(schema_generator)
       end
     end

--- a/lib/ontologies_linked_data/models/properties/object_property.rb
+++ b/lib/ontologies_linked_data/models/properties/object_property.rb
@@ -36,7 +36,7 @@ module LinkedData
               LinkedData::Hypermedia::Link.new("descendants", lambda {|m| "#{self.ontology_link(m)}/properties/#{CGI.escape(m.id.to_s)}/descendants"}, self.uri_type),
               LinkedData::Hypermedia::Link.new("tree", lambda {|m| "#{self.ontology_link(m)}/properties/#{CGI.escape(m.id.to_s)}/tree"}, self.uri_type)
 
-      enable_indexing(:prop_search_core1, :property) do |schema_generator|
+      enable_indexing(:prop_search, :property, bootstrap_collection: :prop_search_bootstrap) do |schema_generator|
         index_schema(schema_generator)
       end
     end

--- a/lib/ontologies_linked_data/models/properties/ontology_property.rb
+++ b/lib/ontologies_linked_data/models/properties/ontology_property.rb
@@ -26,7 +26,7 @@ module LinkedData
         end
       end
 
-      enable_indexing(:prop_search_core1, :property) do |schema_generator|
+      enable_indexing(:prop_search, :property, bootstrap_collection: :prop_search_bootstrap) do |schema_generator|
         index_schema(schema_generator)
       end
 

--- a/lib/ontologies_linked_data/models/provisional_class.rb
+++ b/lib/ontologies_linked_data/models/provisional_class.rb
@@ -40,7 +40,7 @@ module LinkedData
                 end
               }, Goo.vocabulary["Ontology"])
 
-      enable_indexing(:term_search_core1) do |schema_generator|
+      enable_indexing(:term_search, :main, bootstrap_collection: :term_search_bootstrap) do |schema_generator|
         Class.index_schema(schema_generator)
       end
 


### PR DESCRIPTION
## Summary

Renames Solr collection references and enables SolrCloud alias-backed re-indexing for term and property search models.

## Prerequisites

This PR depends on the Goo changes introduced in:

- https://github.com/ncbo/goo/pull/180

### Changes

Models now reference alias names (`:term_search`, `:prop_search`) instead of hardcoded collection names (`:term_search_core1`, `:prop_search_core1`), and declare a `bootstrap_collection:` so Goo can set up the alias-to-collection mapping on first boot.

- **`Class`** and **`ProvisionalClass`**: `enable_indexing(:term_search_core1)` → `enable_indexing(:term_search, :main, bootstrap_collection: :term_search_bootstrap)`
- **`OntologyProperty`**, **`AnnotationProperty`**, **`DatatypeProperty`**, **`ObjectProperty`**: `enable_indexing(:prop_search_core1, :property)` → `enable_indexing(:prop_search, :property, bootstrap_collection: :prop_search_bootstrap)`
- **`Ontology`** and **`OntologySubmission`**: unchanged — these use `enable_indexing(:ontology_metadata)` with no alias, which runs in plain collection mode

### How it works

On first boot, Goo creates the physical collection (e.g. `term_search_bootstrap`) and an alias (`term_search`) pointing to it. All reads and writes go through the alias. During a full re-index, a new collection is created and indexed into, then the alias is atomically swapped — zero downtime.

The `_core1` suffix is dropped entirely since the old dual-core swap pattern no longer applies in SolrCloud.

## Test plan

- [ ] Verify `bundle exec rake test` passes with a running Solr instance
- [ ] Confirm Solr shows aliases `term_search` → `term_search_bootstrap` and `prop_search` → `prop_search_bootstrap` after first boot
- [ ] Confirm existing search and indexing functionality is unaffected (alias is transparent to RSolr reads/writes)