### PR TITLE
Fix /users perf with security: idempotent admin?, drop inverse attrs from auth load

### DIFF
--- a/lib/ontologies_linked_data/models/users/user.rb
+++ b/lib/ontologies_linked_data/models/users/user.rb
@@ -139,7 +139,11 @@ module LinkedData
 
       def admin?
         return false unless persistent?
-        bring(role: [:role])
+        # bring nested role.role only when needed; bring? is checked at both levels
+        # so this is a no-op once cached for the request's remote_user
+        if bring?(:role) || (instance_variable_defined?(:@role) && Array(@role).any? { |r| r.bring?(:role) })
+          bring(role: [:role])
+        end
         return false if role.empty?
         role.map {|r| r.role}.include?(LinkedData::Models::Users::Role::ADMIN)
       end

--- a/lib/ontologies_linked_data/security/authorization.rb
+++ b/lib/ontologies_linked_data/security/authorization.rb
@@ -102,8 +102,17 @@ module LinkedData
         if APIKEYS_FOR_AUTHORIZATION.key?(apikey)
           store_user(APIKEYS_FOR_AUTHORIZATION[apikey], env)
         else
+          # Exclude inverse attributes (e.g. :provisionalClasses) from the auth load —
+          # they fan out across all referencing instances and aren't needed to
+          # establish identity.
+          # TODO: this could be tightened further to an explicit allowlist
+          # (:username, :customOntology, role: [:role] are the only attrs the
+          # middleware and access-control checks actually read on every request);
+          # leaving forward scalars in for now to avoid surprising any callers
+          # that quietly depend on profile fields being preloaded.
+          attrs_to_load = LinkedData::Models::User.attributes(:all) - LinkedData::Models::User.attributes(:inverse)
           user = LinkedData::Models::User.where(apikey: apikey)
-                                         .include(LinkedData::Models::User.attributes(:all))
+                                         .include(attrs_to_load)
                                          .first
           return false if user.nil?
 

--- a/test/models/user/test_user.rb
+++ b/test/models/user/test_user.rb
@@ -82,6 +82,27 @@ class TestUser < LinkedData::TestCase
     u.delete
   end
 
+  # Regression: admin? must succeed when User is loaded with :role only,
+  # without the nested {role: [:role]} pattern. This is the load shape the
+  # auth middleware (Security::Authorization#authorized?) uses on every
+  # authenticated request.
+  def test_admin_with_shallow_role_load
+    admin_role = LinkedData::Models::Users::Role.find("ADMINISTRATOR").include(:role).first
+    @u.role = [admin_role]
+    @u.save
+
+    admin_user = LinkedData::Models::User.where(username: "test_user").include(:role).first
+    assert admin_user.admin?, "admin? must succeed when only :role is loaded"
+    assert admin_user.admin?, "admin? must remain idempotent across calls"
+
+    # And the negative path on the same load shape, to make sure the fix
+    # didn't accidentally collapse to "always true".
+    @u.role = [LinkedData::Models::Users::Role.find("LIBRARIAN").include(:role).first]
+    @u.save
+    librarian_user = LinkedData::Models::User.where(username: "test_user").include(:role).first
+    refute librarian_user.admin?
+  end
+
   def test_user_default_datetime
     u = LinkedData::Models::User.new({
         username: "test_user_datetime",


### PR DESCRIPTION
## Summary
- Make `User#admin?` idempotent so it doesn't re-load `:role` per call.
  `serialize_filter` (added during the agroportal sync for `lastLoginAt`
  visibility) invokes `Thread.current[:remote_user]&.admin?` once per
  serialized user. With security enabled, this turned every authenticated
  `/users?include=all` into an N+1 association reload over the requesting
  user's role.
- Auth middleware: exclude inverse attributes from the User load.
  `attributes(:all)` was including `:provisionalClasses`, which fans out
  across the entire ProvisionalClass graph on every authenticated request.
- Add `test_admin_with_shallow_role_load` covering the auth-middleware
  load shape (admin and non-admin) and the idempotency contract.

Partially addresses ncbo/ontologies_linked_data#285. This PR fixes the
performance issue itself (the per-instance `admin?` fanout and the inverse-attr fanout
in the auth middleware). 
