### PR TITLE
Fix: stale term-search cleanup before reindexing

### DIFF
--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -670,8 +670,7 @@ module LinkedData
         index_commit = options[:index_commit] == false ? false : true
 
         super(*args)
-        self.ontology.unindex(index_commit)
-        self.ontology.unindex_properties(index_commit)
+        self.ontology.unindex_all_data(index_commit)
 
         self.bring(:metrics) if self.bring?(:metrics)
         self.metrics.delete if self.metrics

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
@@ -41,7 +41,7 @@ module LinkedData
           begin
             logger.info("Indexing ontology terms: #{@submission.ontology.acronym}...")
             t0 = Time.now
-            @submission.ontology.unindex(false)
+            @submission.ontology.unindex_by_acronym(false)
             logger.info("Removed ontology terms index (#{Time.now - t0}s)"); logger.flush
 
             paging = LinkedData::Models::Class.in(@submission).include(:unmapped).aggregate(:count, :children).page(page, size)
@@ -304,4 +304,3 @@ module LinkedData
     end
   end
 end
-

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1365,6 +1365,43 @@ eos
     assert_nil RequestStore.store[:requested_lang]
   end
 
+  def test_index_terms_clears_existing_term_docs_by_acronym
+    ontology = mock("ontology")
+    ontology.stubs(:bring?).with(:acronym).returns(false)
+    ontology.stubs(:bring?).with(:provisionalClasses).returns(false)
+    ontology.stubs(:acronym).returns("NPDX")
+    ontology.stubs(:provisionalClasses).returns([])
+    ontology.expects(:unindex_by_acronym).with(false)
+
+    submission = mock("submission")
+    submission.stubs(:bring?).with(:ontology).returns(false)
+    submission.stubs(:ontology).returns(ontology)
+    submission.stubs(:csv_path).returns("/tmp/npdx-classes.csv")
+    submission.stubs(:loaded_attributes).returns([:hasOntologyLanguage])
+    submission.stubs(:hasOntologyLanguage).returns(stub(skos?: true))
+
+    csv_writer = mock("csv-writer")
+    csv_writer.expects(:open).with(ontology, "/tmp/npdx-classes.csv")
+    csv_writer.expects(:close)
+    LinkedData::Utils::OntologyCSVWriter.expects(:new).returns(csv_writer)
+
+    empty_page = stub(total_pages: 0)
+    paging = mock("class-paging")
+    paging.expects(:include).with(:unmapped).returns(paging)
+    paging.expects(:aggregate).with(:count, :children).returns(paging)
+    paging.expects(:page).with(0, 2500).returns(paging)
+    paging.expects(:page).with(1, 2500).returns(paging)
+    paging.expects(:all).returns(empty_page)
+    LinkedData::Models::Class.expects(:in).with(submission).returns(paging)
+
+    indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
+    indexer.stubs(:compute_ancestors_map).returns({})
+
+    indexer.send(:index, Logger.new(TestLogFile.new), false, false)
+  ensure
+    LinkedData::Models::Class.ancestors_cache = nil
+  end
+
   def test_skos_submission_without_skos_concept_processes_without_error
     # Regression for GH-274: SKOS submissions with no skos:Concept previously entered the
     # retry path and failed during missing-label generation because the CSV class_count


### PR DESCRIPTION
## Description

Fixes https://github.com/ncbo/ontologies_api/issues/227.

NPDX suggest/autocomplete search was returning stale capitalized classes from an older ontology submission. Selecting those results led to 404s because the class records were no longer present in the latest NPDX submission.

The term indexer was calling the generic `Ontology#unindex` path before indexing new terms. For ontology records, that path does not perform acronym-scoped class term cleanup, so stale class documents from older submissions could remain in Solr `term_search` and appear in `suggest=true` search results.

## Changes

- Use `unindex_by_acronym(false)` before term reindexing so existing class docs for the ontology acronym are removed from `term_search`.
- Use `unindex_all_data(index_commit)` when deleting ontology submissions so term and property index cleanup go through the explicit cleanup path.
- Add a regression test confirming term indexing clears existing term docs by acronym before continuing.

## Verification

```bash
bundle exec rake test TEST="./test/models/test_ontology_submission.rb" TESTOPTS="--verbose --name=test_index_terms_clears_existing_term_docs_by_acronym"