### PR TITLE
Fix multilingual preferred labels in CSV exports

### DIFF
--- a/lib/ontologies_linked_data/utils/ontology_csv_writer.rb
+++ b/lib/ontologies_linked_data/utils/ontology_csv_writer.rb
@@ -14,6 +14,7 @@ module LinkedData
       SEMANTIC_TYPES = 'Semantic Types'
       OBSOLETE = 'Obsolete'
       PARENTS = 'Parents'
+      UNTAGGED_LABEL_KEYS = [:none, 'none', :'@none', '@none', nil, ''].freeze
 
       def open(ont, path)
         @file = File.new(path, 'w')
@@ -39,7 +40,7 @@ module LinkedData
         row[CLASS_ID] = ont_class.id
 
         # Preferred label
-        row[PREF_LABEL] = Array(ont_class.prefLabel).first
+        row[PREF_LABEL] = preferred_label_for_csv(ont_class)
 
         # Synonyms
         synonyms = ont_class.synonym
@@ -89,6 +90,59 @@ module LinkedData
           parent_ids << parent.id
         end
         return parent_ids.join('|')
+      end
+
+      def preferred_label_for_csv(ont_class)
+        pref_label = csv_pref_label(ont_class)
+        return label_value(pref_label) unless pref_label.is_a?(Hash)
+
+        label_for_language(pref_label) { |language_key| english_label_key?(language_key) } ||
+          label_for_language(pref_label) { |language_key| untagged_label_key?(language_key) } ||
+          first_label_value(pref_label)
+      end
+
+      def csv_pref_label(ont_class)
+        ont_class.prefLabel(include_languages: true)
+      rescue ArgumentError
+        ont_class.prefLabel
+      end
+
+      def label_for_language(labels)
+        labels.each do |language_key, value|
+          next unless yield(language_key)
+
+          label = label_value(value)
+          return label unless label.nil?
+        end
+        nil
+      end
+
+      def english_label_key?(language_key)
+        language_key.to_s.downcase.delete_prefix('@').match?(/\Aen(?:-|$)/)
+      end
+
+      def untagged_label_key?(language_key)
+        UNTAGGED_LABEL_KEYS.include?(language_key)
+      end
+
+      def first_label_value(labels)
+        labels.sort_by { |language_key, _| language_key.to_s }.each do |_, value|
+          label = label_value(value)
+          return label unless label.nil?
+        end
+        nil
+      end
+
+      def label_value(value)
+        Array(value).flatten.each do |label|
+          next if label.nil?
+
+          label = label.id if defined?(Goo::Base::Resource) && label.is_a?(Goo::Base::Resource)
+          label = label.to_s.strip
+          return label unless label.empty?
+        end
+
+        nil
       end
 
       def get_prop_label(prop)

--- a/test/util/test_ontology_csv_writer.rb
+++ b/test/util/test_ontology_csv_writer.rb
@@ -338,4 +338,75 @@ class TestOntologyCSVWriter < LinkedData::TestOntologyCommon
     end
   end
 
+  def test_preferred_label_for_csv_uses_english_label
+    writer = LinkedData::Utils::OntologyCSVWriter.new
+    ont_class = csv_class_with_pref_label(de: 'Deutsches Label', en: 'English label', none: 'Untagged label')
+
+    assert_equal 'English label', writer.preferred_label_for_csv(ont_class)
+  end
+
+  def test_preferred_label_for_csv_uses_english_regional_label
+    writer = LinkedData::Utils::OntologyCSVWriter.new
+    ont_class = csv_class_with_pref_label(:'en-US' => 'English regional label', none: 'Untagged label')
+
+    assert_equal 'English regional label', writer.preferred_label_for_csv(ont_class)
+  end
+
+  def test_preferred_label_for_csv_skips_blank_english_label
+    writer = LinkedData::Utils::OntologyCSVWriter.new
+    ont_class = csv_class_with_pref_label(en: '', 'en' => 'English label', none: 'Untagged label')
+
+    assert_equal 'English label', writer.preferred_label_for_csv(ont_class)
+  end
+
+  def test_preferred_label_for_csv_falls_back_to_untagged_label
+    writer = LinkedData::Utils::OntologyCSVWriter.new
+    ont_class = csv_class_with_pref_label(de: 'Deutsches Label', none: 'Untagged label')
+
+    assert_equal 'Untagged label', writer.preferred_label_for_csv(ont_class)
+  end
+
+  def test_preferred_label_for_csv_preserves_nonblank_label_without_english_or_untagged
+    writer = LinkedData::Utils::OntologyCSVWriter.new
+    ont_class = csv_class_with_pref_label(de: 'Deutsches Label')
+
+    assert_equal 'Deutsches Label', writer.preferred_label_for_csv(ont_class)
+  end
+
+  def test_preferred_label_for_csv_flattens_nested_label_arrays
+    writer = LinkedData::Utils::OntologyCSVWriter.new
+    ont_class = csv_class_with_pref_label(en: [['English label']])
+
+    assert_equal 'English label', writer.preferred_label_for_csv(ont_class)
+  end
+
+  def test_preferred_label_for_csv_supports_legacy_pref_label_method
+    writer = LinkedData::Utils::OntologyCSVWriter.new
+    ont_class = csv_class_with_legacy_pref_label('Legacy label')
+
+    assert_equal 'Legacy label', writer.preferred_label_for_csv(ont_class)
+  end
+
+  def csv_class_with_pref_label(pref_label)
+    Struct.new(:pref_label) do
+      def method_missing(method_name, *)
+        return pref_label if method_name == :prefLabel
+
+        super
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        method_name == :prefLabel || super
+      end
+    end.new(pref_label)
+  end
+
+  def csv_class_with_legacy_pref_label(pref_label)
+    Struct.new(:pref_label) do
+      def prefLabel
+        pref_label
+      end
+    end.new(pref_label)
+  end
+
 end


### PR DESCRIPTION
## Summary
- Keep CSV `Preferred Label` as a single string column
- Prefer English labels, including BCP-47 English variants, then untagged labels
- Add regression coverage for multilingual label selection and legacy `prefLabel` fallback

Fixes #288