### PR TITLE
Fix: incorrect search result ranking - schema and indexer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development do
   gem 'rubocop', require: false
 end
 # NCBO gems (can be from a local dev path or from rubygems/git)
-gem 'goo', github: 'ncbo/goo', branch: 'development'
+gem 'goo', github: 'ncbo/goo', branch: 'fix/incorrect-search-result-ranking'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'development'
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: 5c3a3aca915ebed7cd4ca70be049889756eb47da
+  revision: 684fbe06f8dd9daad10010dc460e06c7ad3a946c
   branch: fix/incorrect-search-result-ranking
   specs:
     goo (0.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: 684fbe06f8dd9daad10010dc460e06c7ad3a946c
+  revision: b29803964525efb1e9f8f77f06ca26973154e14c
   branch: fix/incorrect-search-result-ranking
   specs:
     goo (0.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: 28329ce66ca724ba3652576938e9dc219ca496bf
-  branch: development
+  revision: 5c3a3aca915ebed7cd4ca70be049889756eb47da
+  branch: fix/incorrect-search-result-ranking
   specs:
     goo (0.0.2)
       addressable (~> 2.8)

--- a/lib/ontologies_linked_data/config/config.rb
+++ b/lib/ontologies_linked_data/config/config.rb
@@ -97,9 +97,6 @@ module LinkedData
     # number of times to retry a query when empty records are returned
     @settings.num_retries_4store            ||= 10
 
-    # number of threads to use when indexing a single ontology for search
-    @settings.indexing_num_threads          ||= 1
-
     # Override defaults
     yield @settings, overide_connect_goo if block_given?
     configure_search_collections

--- a/lib/ontologies_linked_data/models/class.rb
+++ b/lib/ontologies_linked_data/models/class.rb
@@ -157,7 +157,7 @@ module LinkedData
         schema_generator.add_copy_field('oboId', '_text_')
 
         %w[prefLabel synonym].each do |field|
-          schema_generator.add_field("#{field}Exact", 'string_ci', indexed: true, stored: false, multi_valued: true)
+          schema_generator.add_field("#{field}Exact", 'string_ci', indexed: true, stored: true, multi_valued: true)
           schema_generator.add_field("#{field}Suggest", 'text_suggest', indexed: true, stored: false, multi_valued: true, omit_norms: true)
           schema_generator.add_field("#{field}SuggestEdge", 'text_suggest_edge', indexed: true, stored: false, multi_valued: true)
           schema_generator.add_field("#{field}SuggestNgram", 'text_suggest_ngram', indexed: true, stored: false, multi_valued: true, omit_norms: true)
@@ -169,7 +169,7 @@ module LinkedData
           schema_generator.add_copy_field(field, "#{field}SuggestNgram")
 
           schema_generator.add_dynamic_field("#{field}_*", 'text_general', indexed: true, stored: true, multi_valued: true)
-          schema_generator.add_dynamic_field("#{field}Exact_*", 'string_ci', indexed: true, stored: false, multi_valued: true)
+          schema_generator.add_dynamic_field("#{field}Exact_*", 'string_ci', indexed: true, stored: true, multi_valued: true)
           schema_generator.add_dynamic_field("#{field}Suggest_*", 'text_suggest', indexed: true, stored: false, multi_valued: true, omit_norms: true)
           schema_generator.add_dynamic_field("#{field}SuggestEdge_*", 'text_suggest_edge', indexed: true, stored: false, multi_valued: true)
           schema_generator.add_dynamic_field("#{field}SuggestNgram_*", 'text_suggest_ngram', indexed: true, stored: false, multi_valued: true, omit_norms: true)

--- a/lib/ontologies_linked_data/models/class.rb
+++ b/lib/ontologies_linked_data/models/class.rb
@@ -141,6 +141,7 @@ module LinkedData
         schema_generator.add_field(:ontologyId, 'string', indexed: true, stored: true, multi_valued: false)
         schema_generator.add_field(:submissionId, 'pint', indexed: true, stored: true, multi_valued: false)
         schema_generator.add_field(:childCount, 'pint', indexed: true, stored: true, multi_valued: false)
+        schema_generator.add_field(:ontologyRank, 'pfloat', indexed: true, stored: true, multi_valued: false, default: 0.0)
 
         schema_generator.add_field(:cui, 'text_general', indexed: true, stored: true, multi_valued: true)
         schema_generator.add_field(:semanticType, 'text_general', indexed: true, stored: true, multi_valued: true)
@@ -156,7 +157,7 @@ module LinkedData
         schema_generator.add_copy_field('oboId', '_text_')
 
         %w[prefLabel synonym].each do |field|
-          schema_generator.add_field("#{field}Exact", 'string', indexed: true, stored: false, multi_valued: true)
+          schema_generator.add_field("#{field}Exact", 'string_ci', indexed: true, stored: false, multi_valued: true)
           schema_generator.add_field("#{field}Suggest", 'text_suggest', indexed: true, stored: false, multi_valued: true, omit_norms: true)
           schema_generator.add_field("#{field}SuggestEdge", 'text_suggest_edge', indexed: true, stored: false, multi_valued: true)
           schema_generator.add_field("#{field}SuggestNgram", 'text_suggest_ngram', indexed: true, stored: false, multi_valued: true, omit_norms: true)
@@ -168,7 +169,7 @@ module LinkedData
           schema_generator.add_copy_field(field, "#{field}SuggestNgram")
 
           schema_generator.add_dynamic_field("#{field}_*", 'text_general', indexed: true, stored: true, multi_valued: true)
-          schema_generator.add_dynamic_field("#{field}Exact_*", 'string', indexed: true, stored: false, multi_valued: true)
+          schema_generator.add_dynamic_field("#{field}Exact_*", 'string_ci', indexed: true, stored: false, multi_valued: true)
           schema_generator.add_dynamic_field("#{field}Suggest_*", 'text_suggest', indexed: true, stored: false, multi_valued: true, omit_norms: true)
           schema_generator.add_dynamic_field("#{field}SuggestEdge_*", 'text_suggest_edge', indexed: true, stored: false, multi_valued: true)
           schema_generator.add_dynamic_field("#{field}SuggestNgram_*", 'text_suggest_ngram', indexed: true, stored: false, multi_valued: true, omit_norms: true)
@@ -218,6 +219,16 @@ module LinkedData
         return nil unless self.submission.ontology
         self.submission.ontology.bring(:acronym) if self.submission.ontology.bring?(:acronym)
         "#{self.id.to_s}_#{self.submission.ontology.acronym}_#{self.submission.submissionId}"
+      end
+
+      def self.reset_ontology_rank_cache
+        @ontology_rank_cache = nil
+      end
+
+      def self.ontology_rank_for_index(acronym)
+        @ontology_rank_cache ||= LinkedData::Models::Ontology.rank
+        rank = @ontology_rank_cache[acronym]
+        rank && !rank.empty? ? rank[:normalizedScore].to_f : 0.0
       end
 
       def to_hash(include_languages: false)
@@ -289,6 +300,7 @@ module LinkedData
           doc[:submissionId] = self.submission.submissionId
           doc[:ontologyType] = self.submission.ontology.ontologyType.get_code_from_id
           doc[:obsolete] = self.obsolete.to_s
+          doc[:ontologyRank] = self.class.ontology_rank_for_index(acronym)
 
           all_attrs = self.to_hash
           std = [:id, :prefLabel, :notation, :synonym, :definition, :cui]

--- a/lib/ontologies_linked_data/models/class.rb
+++ b/lib/ontologies_linked_data/models/class.rb
@@ -157,7 +157,7 @@ module LinkedData
         schema_generator.add_copy_field('oboId', '_text_')
 
         %w[prefLabel synonym].each do |field|
-          schema_generator.add_field("#{field}Exact", 'string_ci', indexed: true, stored: true, multi_valued: true)
+          schema_generator.add_field("#{field}Exact", 'string_ci_exact', indexed: true, stored: true, multi_valued: true)
           schema_generator.add_field("#{field}Suggest", 'text_suggest', indexed: true, stored: false, multi_valued: true, omit_norms: true)
           schema_generator.add_field("#{field}SuggestEdge", 'text_suggest_edge', indexed: true, stored: false, multi_valued: true)
           schema_generator.add_field("#{field}SuggestNgram", 'text_suggest_ngram', indexed: true, stored: false, multi_valued: true, omit_norms: true)
@@ -169,7 +169,7 @@ module LinkedData
           schema_generator.add_copy_field(field, "#{field}SuggestNgram")
 
           schema_generator.add_dynamic_field("#{field}_*", 'text_general', indexed: true, stored: true, multi_valued: true)
-          schema_generator.add_dynamic_field("#{field}Exact_*", 'string_ci', indexed: true, stored: true, multi_valued: true)
+          schema_generator.add_dynamic_field("#{field}Exact_*", 'string_ci_exact', indexed: true, stored: true, multi_valued: true)
           schema_generator.add_dynamic_field("#{field}Suggest_*", 'text_suggest', indexed: true, stored: false, multi_valued: true, omit_norms: true)
           schema_generator.add_dynamic_field("#{field}SuggestEdge_*", 'text_suggest_edge', indexed: true, stored: false, multi_valued: true)
           schema_generator.add_dynamic_field("#{field}SuggestNgram_*", 'text_suggest_ngram', indexed: true, stored: false, multi_valued: true, omit_norms: true)

--- a/lib/ontologies_linked_data/models/concerns/submission_process.rb
+++ b/lib/ontologies_linked_data/models/concerns/submission_process.rb
@@ -30,8 +30,8 @@ module LinkedData
         LinkedData::Services::OntologySubmissionAllDataIndexer.new(self).process(logger, commit: commit)
       end
 
-      def index_terms(logger, commit: true, optimize: true)
-        LinkedData::Services::OntologySubmissionIndexer.new(self).process(logger, commit: commit, optimize: optimize)
+      def index_terms(logger, commit: true, optimize: true, commit_within: 30_000)
+        LinkedData::Services::OntologySubmissionIndexer.new(self).process(logger, commit: commit, optimize: optimize, commit_within: commit_within)
       end
 
       def index_properties(logger, commit: true, optimize: true)

--- a/lib/ontologies_linked_data/models/concerns/submission_process.rb
+++ b/lib/ontologies_linked_data/models/concerns/submission_process.rb
@@ -30,8 +30,8 @@ module LinkedData
         LinkedData::Services::OntologySubmissionAllDataIndexer.new(self).process(logger, commit: commit)
       end
 
-      def index_terms(logger, commit: true, optimize: true, commit_within: 30_000)
-        LinkedData::Services::OntologySubmissionIndexer.new(self).process(logger, commit: commit, optimize: optimize, commit_within: commit_within)
+      def index_terms(logger, commit: true, optimize: true, commit_within: 30_000, generate_csv: true)
+        LinkedData::Services::OntologySubmissionIndexer.new(self).process(logger, commit: commit, optimize: optimize, commit_within: commit_within, generate_csv: generate_csv)
       end
 
       def index_properties(logger, commit: true, optimize: true)

--- a/lib/ontologies_linked_data/models/concerns/submission_process.rb
+++ b/lib/ontologies_linked_data/models/concerns/submission_process.rb
@@ -30,8 +30,8 @@ module LinkedData
         LinkedData::Services::OntologySubmissionAllDataIndexer.new(self).process(logger, commit: commit)
       end
 
-      def index_terms(logger, commit: true, optimize: true, commit_within: 30_000, generate_csv: true)
-        LinkedData::Services::OntologySubmissionIndexer.new(self).process(logger, commit: commit, optimize: optimize, commit_within: commit_within, generate_csv: generate_csv)
+      def index_terms(logger, commit: true, optimize: true, commit_within: 30_000, generate_csv: true, unindex_existing: true)
+        LinkedData::Services::OntologySubmissionIndexer.new(self).process(logger, commit: commit, optimize: optimize, commit_within: commit_within, generate_csv: generate_csv, unindex_existing: unindex_existing)
       end
 
       def index_properties(logger, commit: true, optimize: true)

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
@@ -38,11 +38,9 @@ module LinkedData
         !options[:unindex_existing].eql?(false)
       end
 
-      TERM_INDEX_PAGE_SIZE = 5000
-
-      def index(logger, commit: true, optimize: true, commit_within: 30_000, generate_csv: true, unindex_existing: true, page_size: TERM_INDEX_PAGE_SIZE)
+      def index(logger, commit: true, optimize: true, commit_within: 30_000, generate_csv: true, unindex_existing: true)
         page = 0
-        size = page_size
+        size = 2500
         count_classes = 0
         previous_requested_lang = RequestStore.store[:requested_lang]
 
@@ -88,64 +86,29 @@ module LinkedData
               first_page = paging.page(1, size).all
               total_pages = first_page.total_pages
             end
-            # Fetch one page of classes from the triplestore. Used for the synchronous
-            # fetch of page 1 and for the background prefetch of later pages.
-            #
-            # RequestStore is thread-local, so the :ALL language override set on the
-            # main thread above does NOT propagate to a prefetch thread; it must be set
-            # again here, or the background fetch would drop multilingual values.
-            #
-            # equivalent_predicates is identical for every page (same query shape) and
-            # is returned alongside the page so the consumer never reads it from `paging`
-            # concurrently with a background fetch.
-            fetch_page = lambda do |pnum|
-              RequestStore.store[:requested_lang] = :ALL
-              t_fetch = Time.now
-              page_classes = (pnum == 1 && first_page) ? first_page : paging.page(pnum, size).all
-              # Measure the actual SPARQL fetch wall-time here so the per-page
-              # retrieval timing remains meaningful even when the fetch runs on a
-              # background prefetch thread. (Summing these across pages overcounts,
-              # since prefetched pages overlap the previous page's work — the
-              # overlap is the win; this metric is the raw per-page fetch cost.)
-              [page_classes, paging.equivalent_predicates, Time.now - t_fetch]
-            end
+            page_classes = nil
 
-            # Prime page 1 synchronously, then overlap each page's mapping + Solr write
-            # with the background fetch of the next page. `paging` is mutated by #page,
-            # so only one thread ever touches it at a time: the main thread fetches
-            # page 1, and thereafter each fetch runs on its own thread while the main
-            # thread is busy mapping/indexing and never touching `paging`.
-            current = total_pages >= 1 ? fetch_page.call(1) : nil
-            page = 1
+            while true
+              page = (page == 0 || page_classes.next?) ? page + 1 : nil
+              break if page.nil?
 
-            while current && page <= total_pages
-              page_classes, equivalent_predicates, fetch_seconds = current
+              t0 = Time.now
+              page_classes = (page == 1 && first_page) ? first_page : paging.page(page, size).all
+              count_classes += page_classes.length
 
               if page_classes.empty?
                 logger.info("Page #{page} of #{total_pages} returned no classes. Completing indexing for #{@submission.id.to_s}.")
                 break
               end
 
-              count_classes += page_classes.length
-              logger.info("Page #{page} of #{total_pages} - #{page_classes.length} ontology terms retrieved in #{fetch_seconds} sec.")
-
-              # Kick off the next page's fetch before the CPU-bound mapping so the
-              # triplestore round-trip overlaps with this page's mapping + Solr write.
-              next_page = page + 1
-              next_thread =
-                if next_page <= total_pages
-                  Thread.new(next_page) do |pn|
-                    Thread.current.report_on_exception = false
-                    fetch_page.call(pn)
-                  end
-                end
-
+              logger.info("Page #{page} of #{total_pages} - #{page_classes.length} ontology terms retrieved in #{Time.now - t0} sec.")
               t0 = Time.now
+
               docs = []
               page_classes.each do |c|
                 begin
                   # this call is needed for indexing of properties
-                  LinkedData::Models::Class.map_attributes(c, equivalent_predicates, include_languages: true)
+                  LinkedData::Models::Class.map_attributes(c, paging.equivalent_predicates, include_languages: true)
                 rescue StandardError => e
                   logger.error("Error mapping attributes for #{c.id.to_s}: #{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
                   logger.flush
@@ -168,12 +131,6 @@ module LinkedData
               )
               logger.info("Page #{page} of #{total_pages} - #{page_classes.length} ontology terms indexed in #{Time.now - t0} sec.")
               logger.flush
-
-              # Block until the prefetch completes (usually already done). Thread#value
-              # re-raises a fetch error here on the main thread, where the rescue below
-              # handles it — a failed fetch must not silently drop the remaining pages.
-              current = next_thread&.value
-              page = next_page
             end
 
             csv_writer.close if csv_writer

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
@@ -42,6 +42,7 @@ module LinkedData
         page = 0
         size = 2500
         count_classes = 0
+        previous_requested_lang = RequestStore.store[:requested_lang]
 
         time = Benchmark.realtime do
           @submission.bring(:ontology) if @submission.bring?(:ontology)
@@ -57,6 +58,13 @@ module LinkedData
           LinkedData::Models::Class.ancestors_cache = compute_ancestors_map(logger)
 
           begin
+            # Set once for the whole indexing run; restored in the ensure block below.
+            # In the previous multi-threaded indexer this lived inside per-page worker
+            # threads, so the change was thread-local. Single-threaded, it would otherwise
+            # leak into @submission.save's after_save Solr callback and into the next
+            # ontology's bring_remaining.
+            RequestStore.store[:requested_lang] = :ALL
+
             logger.info("Indexing ontology terms: #{@submission.ontology.acronym}...")
             t0 = Time.now
             if unindex_existing
@@ -84,7 +92,6 @@ module LinkedData
               page = (page == 0 || page_classes.next?) ? page + 1 : nil
               break if page.nil?
 
-              RequestStore.store[:requested_lang] = :ALL
               t0 = Time.now
               page_classes = (page == 1 && first_page) ? first_page : paging.page(page, size).all
               count_classes += page_classes.length
@@ -149,6 +156,7 @@ module LinkedData
             raise e
           ensure
             LinkedData::Models::Class.ancestors_cache = nil
+            RequestStore.store[:requested_lang] = previous_requested_lang
           end
         end
         logger.info("Completed indexing ontology terms: #{@submission.ontology.acronym} in #{time} sec. #{count_classes} classes.")

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
@@ -13,7 +13,11 @@ module LinkedData
 
         status = LinkedData::Models::SubmissionStatus.find('INDEXED').first
         begin
-          index(logger, options[:commit], false, options[:commit_within], generate_csv?(options))
+          index(logger,
+                commit: options[:commit],
+                optimize: false,
+                commit_within: options[:commit_within],
+                generate_csv: generate_csv?(options))
           @submission.add_submission_status(status)
         rescue StandardError => e
           logger.error("#{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
@@ -29,7 +33,7 @@ module LinkedData
         !options[:generate_csv].eql?(false)
       end
 
-      def index(logger, commit = true, optimize = true, commit_within = 30_000, generate_csv = true)
+      def index(logger, commit: true, optimize: true, commit_within: 30_000, generate_csv: true)
         page = 0
         size = 2500
         count_classes = 0

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
@@ -13,19 +13,23 @@ module LinkedData
 
         status = LinkedData::Models::SubmissionStatus.find('INDEXED').first
         begin
-          index(logger, options[:commit], false, options[:commit_within])
+          index(logger, options[:commit], false, options[:commit_within], generate_csv?(options))
           @submission.add_submission_status(status)
         rescue StandardError => e
           logger.error("#{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
           logger.flush
           @submission.add_submission_status(status.get_error_status)
-          FileUtils.rm(@submission.csv_path) if File.file?(@submission.csv_path)
+          FileUtils.rm(@submission.csv_path) if generate_csv?(options) && File.file?(@submission.csv_path)
         ensure
           @submission.save
         end
       end
 
-      def index(logger, commit = true, optimize = true, commit_within = 30_000)
+      def generate_csv?(options)
+        !options[:generate_csv].eql?(false)
+      end
+
+      def index(logger, commit = true, optimize = true, commit_within = 30_000, generate_csv = true)
         page = 0
         size = 2500
         count_classes = 0
@@ -35,8 +39,11 @@ module LinkedData
           @submission.ontology.bring(:acronym) if @submission.ontology.bring?(:acronym)
           @submission.ontology.bring(:provisionalClasses) if @submission.ontology.bring?(:provisionalClasses)
           LinkedData::Models::Class.reset_ontology_rank_cache
-          csv_writer = LinkedData::Utils::OntologyCSVWriter.new
-          csv_writer.open(@submission.ontology, @submission.csv_path)
+          csv_writer = nil
+          if generate_csv
+            csv_writer = LinkedData::Utils::OntologyCSVWriter.new
+            csv_writer.open(@submission.ontology, @submission.csv_path)
+          end
 
           LinkedData::Models::Class.ancestors_cache = compute_ancestors_map(logger)
 
@@ -90,7 +97,7 @@ module LinkedData
                 # TODO: Remove once precomputed ancestors are validated against production data
                 validate_class_ancestors(c, logger) if ENV['OP_VALIDATE_ANCESTORS']
 
-                csv_writer.write_class(c)
+                csv_writer.write_class(c) if csv_writer
                 docs << c.indexable_object
               end
               logger.info("Page #{page} of #{total_pages} attributes mapped in #{Time.now - t0} sec.")
@@ -106,7 +113,7 @@ module LinkedData
               logger.flush
             end
 
-            csv_writer.close
+            csv_writer.close if csv_writer
 
             begin
               # index provisional classes
@@ -123,7 +130,7 @@ module LinkedData
               logger.info("Ontology terms index commit in #{Time.now - t0} sec.")
             end
           rescue StandardError => e
-            csv_writer.close
+            csv_writer.close if csv_writer
             logger.error("\n\n#{e.class}: #{e.message}\n")
             logger.error(e.backtrace)
             raise e

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
@@ -40,7 +40,7 @@ module LinkedData
 
       def index(logger, commit: true, optimize: true, commit_within: 30_000, generate_csv: true, unindex_existing: true)
         page = 0
-        size = 2500
+        size = 5000
         count_classes = 0
         previous_requested_lang = RequestStore.store[:requested_lang]
 

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
@@ -38,9 +38,11 @@ module LinkedData
         !options[:unindex_existing].eql?(false)
       end
 
-      def index(logger, commit: true, optimize: true, commit_within: 30_000, generate_csv: true, unindex_existing: true)
+      TERM_INDEX_PAGE_SIZE = 5000
+
+      def index(logger, commit: true, optimize: true, commit_within: 30_000, generate_csv: true, unindex_existing: true, page_size: TERM_INDEX_PAGE_SIZE)
         page = 0
-        size = 5000
+        size = page_size
         count_classes = 0
         previous_requested_lang = RequestStore.store[:requested_lang]
 
@@ -86,29 +88,64 @@ module LinkedData
               first_page = paging.page(1, size).all
               total_pages = first_page.total_pages
             end
-            page_classes = nil
+            # Fetch one page of classes from the triplestore. Used for the synchronous
+            # fetch of page 1 and for the background prefetch of later pages.
+            #
+            # RequestStore is thread-local, so the :ALL language override set on the
+            # main thread above does NOT propagate to a prefetch thread; it must be set
+            # again here, or the background fetch would drop multilingual values.
+            #
+            # equivalent_predicates is identical for every page (same query shape) and
+            # is returned alongside the page so the consumer never reads it from `paging`
+            # concurrently with a background fetch.
+            fetch_page = lambda do |pnum|
+              RequestStore.store[:requested_lang] = :ALL
+              t_fetch = Time.now
+              page_classes = (pnum == 1 && first_page) ? first_page : paging.page(pnum, size).all
+              # Measure the actual SPARQL fetch wall-time here so the per-page
+              # retrieval timing remains meaningful even when the fetch runs on a
+              # background prefetch thread. (Summing these across pages overcounts,
+              # since prefetched pages overlap the previous page's work — the
+              # overlap is the win; this metric is the raw per-page fetch cost.)
+              [page_classes, paging.equivalent_predicates, Time.now - t_fetch]
+            end
 
-            while true
-              page = (page == 0 || page_classes.next?) ? page + 1 : nil
-              break if page.nil?
+            # Prime page 1 synchronously, then overlap each page's mapping + Solr write
+            # with the background fetch of the next page. `paging` is mutated by #page,
+            # so only one thread ever touches it at a time: the main thread fetches
+            # page 1, and thereafter each fetch runs on its own thread while the main
+            # thread is busy mapping/indexing and never touching `paging`.
+            current = total_pages >= 1 ? fetch_page.call(1) : nil
+            page = 1
 
-              t0 = Time.now
-              page_classes = (page == 1 && first_page) ? first_page : paging.page(page, size).all
-              count_classes += page_classes.length
+            while current && page <= total_pages
+              page_classes, equivalent_predicates, fetch_seconds = current
 
               if page_classes.empty?
                 logger.info("Page #{page} of #{total_pages} returned no classes. Completing indexing for #{@submission.id.to_s}.")
                 break
               end
 
-              logger.info("Page #{page} of #{total_pages} - #{page_classes.length} ontology terms retrieved in #{Time.now - t0} sec.")
-              t0 = Time.now
+              count_classes += page_classes.length
+              logger.info("Page #{page} of #{total_pages} - #{page_classes.length} ontology terms retrieved in #{fetch_seconds} sec.")
 
+              # Kick off the next page's fetch before the CPU-bound mapping so the
+              # triplestore round-trip overlaps with this page's mapping + Solr write.
+              next_page = page + 1
+              next_thread =
+                if next_page <= total_pages
+                  Thread.new(next_page) do |pn|
+                    Thread.current.report_on_exception = false
+                    fetch_page.call(pn)
+                  end
+                end
+
+              t0 = Time.now
               docs = []
               page_classes.each do |c|
                 begin
                   # this call is needed for indexing of properties
-                  LinkedData::Models::Class.map_attributes(c, paging.equivalent_predicates, include_languages: true)
+                  LinkedData::Models::Class.map_attributes(c, equivalent_predicates, include_languages: true)
                 rescue StandardError => e
                   logger.error("Error mapping attributes for #{c.id.to_s}: #{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
                   logger.flush
@@ -131,6 +168,12 @@ module LinkedData
               )
               logger.info("Page #{page} of #{total_pages} - #{page_classes.length} ontology terms indexed in #{Time.now - t0} sec.")
               logger.flush
+
+              # Block until the prefetch completes (usually already done). Thread#value
+              # re-raises a fetch error here on the main thread, where the rescue below
+              # handles it — a failed fetch must not silently drop the remaining pages.
+              current = next_thread&.value
+              page = next_page
             end
 
             csv_writer.close if csv_writer

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
@@ -17,7 +17,8 @@ module LinkedData
                 commit: options[:commit],
                 optimize: false,
                 commit_within: options[:commit_within],
-                generate_csv: generate_csv?(options))
+                generate_csv: generate_csv?(options),
+                unindex_existing: unindex_existing?(options))
           @submission.add_submission_status(status)
         rescue StandardError => e
           logger.error("#{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
@@ -33,7 +34,11 @@ module LinkedData
         !options[:generate_csv].eql?(false)
       end
 
-      def index(logger, commit: true, optimize: true, commit_within: 30_000, generate_csv: true)
+      def unindex_existing?(options)
+        !options[:unindex_existing].eql?(false)
+      end
+
+      def index(logger, commit: true, optimize: true, commit_within: 30_000, generate_csv: true, unindex_existing: true)
         page = 0
         size = 2500
         count_classes = 0
@@ -54,8 +59,12 @@ module LinkedData
           begin
             logger.info("Indexing ontology terms: #{@submission.ontology.acronym}...")
             t0 = Time.now
-            @submission.ontology.unindex_by_acronym(false)
-            logger.info("Removed ontology terms index (#{Time.now - t0}s)"); logger.flush
+            if unindex_existing
+              @submission.ontology.unindex_by_acronym(false)
+              logger.info("Removed ontology terms index (#{Time.now - t0}s)"); logger.flush
+            else
+              logger.info("Skipping unindex_by_acronym (fresh target collection)"); logger.flush
+            end
 
             paging = LinkedData::Models::Class.in(@submission).include(:unmapped).aggregate(:count, :children).page(page, size)
             # a fix for SKOS ontologies, see https://github.com/ncbo/ontologies_api/issues/20

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_indexer.rb
@@ -9,10 +9,11 @@ module LinkedData
       private
 
       def process_indexation(logger, options)
+        options ||= {}
 
         status = LinkedData::Models::SubmissionStatus.find('INDEXED').first
         begin
-          index(logger, options[:commit], false)
+          index(logger, options[:commit], false, options[:commit_within])
           @submission.add_submission_status(status)
         rescue StandardError => e
           logger.error("#{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
@@ -24,7 +25,7 @@ module LinkedData
         end
       end
 
-      def index(logger, commit = true, optimize = true)
+      def index(logger, commit = true, optimize = true, commit_within = 30_000)
         page = 0
         size = 2500
         count_classes = 0
@@ -33,6 +34,7 @@ module LinkedData
           @submission.bring(:ontology) if @submission.bring?(:ontology)
           @submission.ontology.bring(:acronym) if @submission.ontology.bring?(:acronym)
           @submission.ontology.bring(:provisionalClasses) if @submission.ontology.bring?(:provisionalClasses)
+          LinkedData::Models::Class.reset_ontology_rank_cache
           csv_writer = LinkedData::Utils::OntologyCSVWriter.new
           csv_writer.open(@submission.ontology, @submission.csv_path)
 
@@ -48,122 +50,62 @@ module LinkedData
             # a fix for SKOS ontologies, see https://github.com/ncbo/ontologies_api/issues/20
             @submission.bring(:hasOntologyLanguage) unless @submission.loaded_attributes.include?(:hasOntologyLanguage)
             cls_count = @submission.hasOntologyLanguage.skos? ? -1 : @submission.class_count(logger)
-            paging.page_count_set(cls_count) unless cls_count < 0
-            total_pages = paging.page(1, size).all.total_pages
-            num_threads = [total_pages, LinkedData.settings.indexing_num_threads].min
-            threads = []
+            first_page = nil
+            if cls_count >= 0
+              paging.page_count_set(cls_count)
+              total_pages = (cls_count / size.to_f).ceil
+            else
+              first_page = paging.page(1, size).all
+              total_pages = first_page.total_pages
+            end
             page_classes = nil
 
-            num_threads.times do |num|
-              threads[num] = Thread.new {
-                Thread.current['done'] = false
-                Thread.current['page_len'] = -1
-                Thread.current['prev_page_len'] = -1
+            while true
+              page = (page == 0 || page_classes.next?) ? page + 1 : nil
+              break if page.nil?
 
-                while !Thread.current['done']
-                  @submission.synchronize do
-                    page = (page == 0 || page_classes.next?) ? page + 1 : nil
+              RequestStore.store[:requested_lang] = :ALL
+              t0 = Time.now
+              page_classes = (page == 1 && first_page) ? first_page : paging.page(page, size).all
+              count_classes += page_classes.length
 
-                    if page.nil?
-                      Thread.current['done'] = true
-                    else
-                      Thread.current['page'] = page || 'nil'
-                      RequestStore.store[:requested_lang] = :ALL
-                      page_classes = paging.page(page, size).all
-                      count_classes += page_classes.length
-                      Thread.current['page_classes'] = page_classes
-                      Thread.current['page_len'] = page_classes.length
-                      Thread.current['t0'] = Time.now
+              if page_classes.empty?
+                logger.info("Page #{page} of #{total_pages} returned no classes. Completing indexing for #{@submission.id.to_s}.")
+                break
+              end
 
-                      # nothing retrieved even though we're expecting more records
-                      if total_pages > 0 && page_classes.empty? && (Thread.current['prev_page_len'] == -1 || Thread.current['prev_page_len'] == size)
-                        j = 0
-                        num_calls = LinkedData.settings.num_retries_4store
+              logger.info("Page #{page} of #{total_pages} - #{page_classes.length} ontology terms retrieved in #{Time.now - t0} sec.")
+              t0 = Time.now
 
-                        while page_classes.empty? && j < num_calls do
-                          j += 1
-                          logger.error("Thread #{num + 1}: Empty page encountered. Retrying #{j} times...")
-                          sleep(2)
-                          page_classes = paging.page(page, size).all
-                          logger.info("Thread #{num + 1}: Success retrieving a page of #{page_classes.length} classes after retrying #{j} times...") unless page_classes.empty?
-                        end
-
-                        if page_classes.empty?
-                          msg = "Thread #{num + 1}: Empty page #{Thread.current["page"]} of #{total_pages} persisted after retrying #{j} times. Indexing of #{@submission.id.to_s} aborted..."
-                          logger.error(msg)
-                          raise msg
-                        else
-                          Thread.current['page_classes'] = page_classes
-                        end
-                      end
-
-                      if page_classes.empty?
-                        if total_pages > 0
-                          logger.info("Thread #{num + 1}: The number of pages reported for #{@submission.id.to_s} - #{total_pages} is higher than expected #{page - 1}. Completing indexing...")
-                        else
-                          logger.info("Thread #{num + 1}: Ontology #{@submission.id.to_s} contains #{total_pages} pages...")
-                        end
-
-                        break
-                      end
-
-                      Thread.current['prev_page_len'] = Thread.current['page_len']
-                    end
-                  end
-
-                  break if Thread.current['done']
-
-                  logger.info("Thread #{num + 1}: Page #{Thread.current["page"]} of #{total_pages} - #{Thread.current["page_len"]} ontology terms retrieved in #{Time.now - Thread.current["t0"]} sec.")
-                  Thread.current['t0'] = Time.now
-
-                  Thread.current['page_classes'].each do |c|
-                    begin
-                      # this cal is needed for indexing of properties
-                      LinkedData::Models::Class.map_attributes(c, paging.equivalent_predicates, include_languages: true)
-                    rescue Exception
-                      i = 0
-                      num_calls = LinkedData.settings.num_retries_4store
-                      success = nil
-
-                      while success.nil? && i < num_calls do
-                        i += 1
-                        logger.error("Thread #{num + 1}: Exception while mapping attributes for #{c.id.to_s}. Retrying #{i} times...")
-                        sleep(2)
-
-                        begin
-                          LinkedData::Models::Class.map_attributes(c, paging.equivalent_predicates, include_languages: true)
-                          logger.info("Thread #{num + 1}: Success mapping attributes for #{c.id.to_s} after retrying #{i} times...")
-                          success = true
-                        rescue Exception => e1
-                          success = nil
-
-                          if i == num_calls
-                            logger.error("Thread #{num + 1}: Error mapping attributes for #{c.id.to_s}:")
-                            logger.error("Thread #{num + 1}: #{e1.class}: #{e1.message} after retrying #{i} times...\n#{e1.backtrace.join("\n\t")}")
-                            logger.flush
-                          end
-                        end
-                      end
-                    end
-
-                    # TODO: Remove once precomputed ancestors are validated against production data
-                    validate_class_ancestors(c, logger) if ENV['OP_VALIDATE_ANCESTORS']
-
-                    @submission.synchronize do
-                      csv_writer.write_class(c)
-                    end
-                  end
-                  logger.info("Thread #{num + 1}: Page #{Thread.current["page"]} of #{total_pages} attributes mapped in #{Time.now - Thread.current["t0"]} sec.")
-
-                  Thread.current['t0'] = Time.now
-                  LinkedData::Models::Class.indexBatch(Thread.current['page_classes'])
-                  logger.info("Thread #{num + 1}: Page #{Thread.current["page"]} of #{total_pages} - #{Thread.current["page_len"]} ontology terms indexed in #{Time.now - Thread.current["t0"]} sec.")
+              docs = []
+              page_classes.each do |c|
+                begin
+                  # this call is needed for indexing of properties
+                  LinkedData::Models::Class.map_attributes(c, paging.equivalent_predicates, include_languages: true)
+                rescue StandardError => e
+                  logger.error("Error mapping attributes for #{c.id.to_s}: #{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
                   logger.flush
                 end
-              }
+
+                # TODO: Remove once precomputed ancestors are validated against production data
+                validate_class_ancestors(c, logger) if ENV['OP_VALIDATE_ANCESTORS']
+
+                csv_writer.write_class(c)
+                docs << c.indexable_object
+              end
+              logger.info("Page #{page} of #{total_pages} attributes mapped in #{Time.now - t0} sec.")
+
+              t0 = Time.now
+              page_commit = commit && !commit_within.nil?
+              LinkedData::Models::Class.search_client.index_document(
+                docs,
+                commit: page_commit,
+                commit_within: page_commit ? commit_within : nil
+              )
+              logger.info("Page #{page} of #{total_pages} - #{page_classes.length} ontology terms indexed in #{Time.now - t0} sec.")
+              logger.flush
             end
 
-            threads.map { |t| t.join }
             csv_writer.close
 
             begin

--- a/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
+++ b/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
@@ -42,6 +42,10 @@ module LinkedData
 
             @submission = @submission.extract_metadata(logger, user_params: options[:params], heavy_extraction: extract_metadata?(options))
 
+            if @submission.nil?
+              raise StandardError, "Submission processing aborted: extract_metadata returned nil (submission failed validation; see per-submission parsing.log)"
+            end
+
             @submission.generate_missing_labels(logger) if generate_missing_labels?(options)
 
             @submission.generate_obsolete_classes(logger) if generate_obsolete_classes?(options)
@@ -72,7 +76,8 @@ module LinkedData
       end
 
       def notify_submission_processed(logger)
-        LinkedData::Utils::Notifications.submission_processed(@submission) unless @submission.archived?
+        return if @submission.nil? || @submission.archived?
+        LinkedData::Utils::Notifications.submission_processed(@submission)
       rescue StandardError => e
         logger.error("Email sending failed: #{e.message}\n#{e.backtrace.join("\n\t")}"); logger.flush
       end

--- a/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
+++ b/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
@@ -9,6 +9,7 @@ module LinkedData
       #   index_properties  = false
       #   index_commit      = false
       #   generate_csv      = true
+      #   unindex_existing  = true
       #   run_metrics       = false
       #   reasoning         = false
       #   diff              = false
@@ -52,7 +53,7 @@ module LinkedData
 
             @submission.index_all(logger, commit: process_index_commit?(options)) if index_all_data?(options)
 
-            @submission.index_terms(logger, commit: process_index_commit?(options), commit_within: index_commit_within(options), generate_csv: generate_csv?(options)) if index_search?(options)
+            @submission.index_terms(logger, commit: process_index_commit?(options), commit_within: index_commit_within(options), generate_csv: generate_csv?(options), unindex_existing: unindex_existing?(options)) if index_search?(options)
 
             @submission.index_properties(logger, commit: process_index_commit?(options)) if index_properties?(options)
 
@@ -116,6 +117,10 @@ module LinkedData
 
       def generate_csv?(options)
         !options[:generate_csv].eql?(false)
+      end
+
+      def unindex_existing?(options)
+        !options[:unindex_existing].eql?(false)
       end
 
       def process_diff?(options)

--- a/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
+++ b/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
@@ -8,6 +8,7 @@ module LinkedData
       #   index_search      = false
       #   index_properties  = false
       #   index_commit      = false
+      #   generate_csv      = true
       #   run_metrics       = false
       #   reasoning         = false
       #   diff              = false
@@ -51,7 +52,7 @@ module LinkedData
 
             @submission.index_all(logger, commit: process_index_commit?(options)) if index_all_data?(options)
 
-            @submission.index_terms(logger, commit: process_index_commit?(options), commit_within: index_commit_within(options)) if index_search?(options)
+            @submission.index_terms(logger, commit: process_index_commit?(options), commit_within: index_commit_within(options), generate_csv: generate_csv?(options)) if index_search?(options)
 
             @submission.index_properties(logger, commit: process_index_commit?(options)) if index_properties?(options)
 
@@ -111,6 +112,10 @@ module LinkedData
 
       def index_commit_within(options)
         options.key?(:index_commit_within) ? options[:index_commit_within] : 30_000
+      end
+
+      def generate_csv?(options)
+        !options[:generate_csv].eql?(false)
       end
 
       def process_diff?(options)

--- a/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
+++ b/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
@@ -104,6 +104,8 @@ module LinkedData
       end
 
       def process_index_commit?(options)
+        return false if options[:index_commit].eql?(false)
+
         index_search?(options) || index_properties?(options) || index_all_data?(options)
       end
 

--- a/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
+++ b/lib/ontologies_linked_data/services/submission_process/submission_processor.rb
@@ -51,7 +51,7 @@ module LinkedData
 
             @submission.index_all(logger, commit: process_index_commit?(options)) if index_all_data?(options)
 
-            @submission.index_terms(logger, commit: process_index_commit?(options)) if index_search?(options)
+            @submission.index_terms(logger, commit: process_index_commit?(options), commit_within: index_commit_within(options)) if index_search?(options)
 
             @submission.index_properties(logger, commit: process_index_commit?(options)) if index_properties?(options)
 
@@ -105,6 +105,10 @@ module LinkedData
 
       def process_index_commit?(options)
         index_search?(options) || index_properties?(options) || index_all_data?(options)
+      end
+
+      def index_commit_within(options)
+        options.key?(:index_commit_within) ? options[:index_commit_within] : 30_000
       end
 
       def process_diff?(options)

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1379,13 +1379,16 @@ eos
     submission.stubs(:csv_path).returns("/tmp/npdx-classes.csv")
     submission.stubs(:loaded_attributes).returns([:hasOntologyLanguage])
     submission.stubs(:hasOntologyLanguage).returns(stub(skos?: true))
+    submission.stubs(:id).returns(RDF::URI.new("http://example.org/submissions/npdx"))
 
     csv_writer = mock("csv-writer")
     csv_writer.expects(:open).with(ontology, "/tmp/npdx-classes.csv")
     csv_writer.expects(:close)
     LinkedData::Utils::OntologyCSVWriter.expects(:new).returns(csv_writer)
 
-    empty_page = stub(total_pages: 0)
+    empty_page = []
+    empty_page.define_singleton_method(:total_pages) { 0 }
+    empty_page.define_singleton_method(:next?) { false }
     paging = mock("class-paging")
     paging.expects(:include).with(:unmapped).returns(paging)
     paging.expects(:aggregate).with(:count, :children).returns(paging)
@@ -1393,6 +1396,70 @@ eos
     paging.expects(:page).with(1, 2500).returns(paging)
     paging.expects(:all).returns(empty_page)
     LinkedData::Models::Class.expects(:in).with(submission).returns(paging)
+
+    indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
+    indexer.stubs(:compute_ancestors_map).returns({})
+
+    indexer.send(:index, Logger.new(TestLogFile.new), false, false)
+  ensure
+    LinkedData::Models::Class.ancestors_cache = nil
+  end
+
+  def test_index_terms_sets_total_pages_from_class_count_without_prefetching_first_page
+    ontology = mock("ontology")
+    ontology.stubs(:bring?).with(:acronym).returns(false)
+    ontology.stubs(:bring?).with(:provisionalClasses).returns(false)
+    ontology.stubs(:acronym).returns("PAGING")
+    ontology.stubs(:provisionalClasses).returns([])
+    ontology.expects(:unindex_by_acronym).with(false)
+
+    language = mock("language")
+    language.expects(:skos?).returns(false)
+
+    submission = mock("submission")
+    submission.stubs(:bring?).with(:ontology).returns(false)
+    submission.stubs(:ontology).returns(ontology)
+    submission.stubs(:csv_path).returns("/tmp/paging-classes.csv")
+    submission.stubs(:loaded_attributes).returns([:hasOntologyLanguage])
+    submission.stubs(:hasOntologyLanguage).returns(language)
+    submission.stubs(:class_count).returns(2501)
+    submission.stubs(:id).returns(RDF::URI.new("http://example.org/submissions/1"))
+
+    first_class = stub("first-class", id: RDF::URI.new("http://example.org/classes/1"), indexable_object: { id: "1" })
+    second_class = stub("second-class", id: RDF::URI.new("http://example.org/classes/2"), indexable_object: { id: "2" })
+    page_one = [first_class]
+    page_one.define_singleton_method(:next?) { true }
+    page_two = [second_class]
+    page_two.define_singleton_method(:next?) { false }
+
+    csv_writer = mock("csv-writer")
+    csv_writer.expects(:open).with(ontology, "/tmp/paging-classes.csv")
+    csv_writer.expects(:write_class).with(first_class)
+    csv_writer.expects(:write_class).with(second_class)
+    csv_writer.expects(:close)
+    LinkedData::Utils::OntologyCSVWriter.expects(:new).returns(csv_writer)
+
+    first_page_scope = mock("first-page-scope")
+    first_page_scope.expects(:all).returns(page_one)
+    second_page_scope = mock("second-page-scope")
+    second_page_scope.expects(:all).returns(page_two)
+
+    paging = mock("class-paging")
+    paging.expects(:include).with(:unmapped).returns(paging)
+    paging.expects(:aggregate).with(:count, :children).returns(paging)
+    paging.expects(:page).with(0, 2500).returns(paging)
+    paging.expects(:page_count_set).with(2501)
+    paging.expects(:page).with(1, 2500).once.returns(first_page_scope)
+    paging.expects(:page).with(2, 2500).once.returns(second_page_scope)
+    paging.stubs(:equivalent_predicates).returns({})
+    LinkedData::Models::Class.expects(:in).with(submission).returns(paging)
+    LinkedData::Models::Class.expects(:map_attributes).with(first_class, {}, include_languages: true)
+    LinkedData::Models::Class.expects(:map_attributes).with(second_class, {}, include_languages: true)
+
+    search_client = mock("search-client")
+    search_client.expects(:index_document).with([{ id: "1" }], commit: false, commit_within: nil)
+    search_client.expects(:index_document).with([{ id: "2" }], commit: false, commit_within: nil)
+    LinkedData::Models::Class.expects(:search_client).twice.returns(search_client)
 
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1400,7 +1400,7 @@ eos
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})
 
-    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false)
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, page_size: 2500)
   ensure
     LinkedData::Models::Class.ancestors_cache = nil
   end
@@ -1464,7 +1464,7 @@ eos
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})
 
-    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false)
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, page_size: 2500)
   ensure
     LinkedData::Models::Class.ancestors_cache = nil
   end
@@ -1500,7 +1500,7 @@ eos
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})
 
-    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, commit_within: nil, generate_csv: false)
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, commit_within: nil, generate_csv: false, page_size: 2500)
   ensure
     LinkedData::Models::Class.ancestors_cache = nil
   end
@@ -1541,9 +1541,242 @@ eos
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})
 
-    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, unindex_existing: false)
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, unindex_existing: false, page_size: 2500)
   ensure
     LinkedData::Models::Class.ancestors_cache = nil
+  end
+
+  def test_index_terms_indexes_all_pages_in_order
+    ontology = mock("ontology")
+    ontology.stubs(:bring?).with(:acronym).returns(false)
+    ontology.stubs(:bring?).with(:provisionalClasses).returns(false)
+    ontology.stubs(:acronym).returns("ORDER")
+    ontology.stubs(:provisionalClasses).returns([])
+    ontology.expects(:unindex_by_acronym).with(false)
+
+    language = mock("language")
+    language.expects(:skos?).returns(false)
+
+    submission = mock("submission")
+    submission.stubs(:bring?).with(:ontology).returns(false)
+    submission.stubs(:ontology).returns(ontology)
+    submission.stubs(:csv_path).returns("/tmp/order-classes.csv")
+    submission.stubs(:loaded_attributes).returns([:hasOntologyLanguage])
+    submission.stubs(:hasOntologyLanguage).returns(language)
+    submission.stubs(:class_count).returns(5)
+    submission.stubs(:id).returns(RDF::URI.new("http://example.org/submissions/order"))
+
+    classes = (1..5).map do |i|
+      stub("c#{i}", id: RDF::URI.new("http://example.org/c/#{i}"), indexable_object: { id: i.to_s })
+    end
+    page_one   = [classes[0], classes[1]]
+    page_two   = [classes[2], classes[3]]
+    page_three = [classes[4]]
+
+    csv_writer = mock("csv-writer")
+    csv_writer.expects(:open).with(ontology, "/tmp/order-classes.csv")
+    csv_writer.stubs(:write_class)
+    csv_writer.expects(:close)
+    LinkedData::Utils::OntologyCSVWriter.expects(:new).returns(csv_writer)
+
+    scope_one   = mock("scope-1"); scope_one.expects(:all).returns(page_one)
+    scope_two   = mock("scope-2"); scope_two.expects(:all).returns(page_two)
+    scope_three = mock("scope-3"); scope_three.expects(:all).returns(page_three)
+
+    paging = mock("class-paging")
+    paging.expects(:include).with(:unmapped).returns(paging)
+    paging.expects(:aggregate).with(:count, :children).returns(paging)
+    paging.expects(:page).with(0, 2).returns(paging)
+    paging.expects(:page_count_set).with(5)
+    paging.expects(:page).with(1, 2).once.returns(scope_one)
+    paging.expects(:page).with(2, 2).once.returns(scope_two)
+    paging.expects(:page).with(3, 2).once.returns(scope_three)
+    paging.stubs(:equivalent_predicates).returns({})
+    LinkedData::Models::Class.expects(:in).with(submission).returns(paging)
+
+    classes.each do |c|
+      LinkedData::Models::Class.expects(:map_attributes).with(c, {}, include_languages: true)
+    end
+
+    index_seq = sequence("index-order")
+    search_client = mock("search-client")
+    search_client.expects(:index_document).with([{ id: "1" }, { id: "2" }], commit: false, commit_within: nil).in_sequence(index_seq)
+    search_client.expects(:index_document).with([{ id: "3" }, { id: "4" }], commit: false, commit_within: nil).in_sequence(index_seq)
+    search_client.expects(:index_document).with([{ id: "5" }], commit: false, commit_within: nil).in_sequence(index_seq)
+    LinkedData::Models::Class.stubs(:search_client).returns(search_client)
+
+    indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
+    indexer.stubs(:compute_ancestors_map).returns({})
+
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, page_size: 2)
+  ensure
+    LinkedData::Models::Class.ancestors_cache = nil
+  end
+
+  def test_index_terms_sets_requested_lang_all_in_background_fetch_thread
+    # RequestStore is thread-local. The page-prefetch thread must set
+    # requested_lang = :ALL itself; otherwise the background fetch would run
+    # under the wrong language and drop multilingual values. This asserts the
+    # value observed *during the background fetch* is :ALL.
+    ontology = mock("ontology")
+    ontology.stubs(:bring?).with(:acronym).returns(false)
+    ontology.stubs(:bring?).with(:provisionalClasses).returns(false)
+    ontology.stubs(:acronym).returns("LANG")
+    ontology.stubs(:provisionalClasses).returns([])
+    ontology.expects(:unindex_by_acronym).with(false)
+
+    language = mock("language")
+    language.expects(:skos?).returns(false)
+
+    submission = mock("submission")
+    submission.stubs(:bring?).with(:ontology).returns(false)
+    submission.stubs(:ontology).returns(ontology)
+    submission.stubs(:csv_path).returns("/tmp/lang-classes.csv")
+    submission.stubs(:loaded_attributes).returns([:hasOntologyLanguage])
+    submission.stubs(:hasOntologyLanguage).returns(language)
+    submission.stubs(:class_count).returns(3)
+    submission.stubs(:id).returns(RDF::URI.new("http://example.org/submissions/lang"))
+
+    c1 = stub("c1", id: RDF::URI.new("http://example.org/c/1"), indexable_object: { id: "1" })
+    c2 = stub("c2", id: RDF::URI.new("http://example.org/c/2"), indexable_object: { id: "2" })
+    page_one = [c1]
+    page_two = [c2]
+
+    captured_langs = Queue.new
+    # page 2 is the one fetched on the background thread; capture the
+    # thread-local lang observed when its fetch executes.
+    page_two_scope = Object.new
+    page_two_scope.define_singleton_method(:all) do
+      captured_langs << RequestStore.store[:requested_lang]
+      page_two
+    end
+
+    csv_writer = mock("csv-writer")
+    csv_writer.stubs(:open)
+    csv_writer.stubs(:write_class)
+    csv_writer.stubs(:close)
+    LinkedData::Utils::OntologyCSVWriter.expects(:new).returns(csv_writer)
+
+    first_page_scope = mock("first-page-scope")
+    first_page_scope.expects(:all).returns(page_one)
+
+    paging = mock("class-paging")
+    paging.expects(:include).with(:unmapped).returns(paging)
+    paging.expects(:aggregate).with(:count, :children).returns(paging)
+    paging.expects(:page).with(0, 2).returns(paging)
+    paging.expects(:page_count_set).with(3)
+    paging.expects(:page).with(1, 2).returns(first_page_scope)
+    paging.expects(:page).with(2, 2).returns(page_two_scope)
+    paging.stubs(:equivalent_predicates).returns({})
+    LinkedData::Models::Class.expects(:in).with(submission).returns(paging)
+    LinkedData::Models::Class.stubs(:map_attributes)
+
+    search_client = mock("search-client")
+    search_client.stubs(:index_document)
+    LinkedData::Models::Class.stubs(:search_client).returns(search_client)
+
+    indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
+    indexer.stubs(:compute_ancestors_map).returns({})
+
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, page_size: 2)
+
+    langs = []
+    langs << captured_langs.pop until captured_langs.empty?
+    assert_includes langs, :ALL, "background page fetch must run with requested_lang = :ALL"
+  ensure
+    LinkedData::Models::Class.ancestors_cache = nil
+  end
+
+  def test_index_terms_reraises_background_page_fetch_errors
+    # A failed page fetch must surface, not silently drop the remaining pages.
+    ontology = mock("ontology")
+    ontology.stubs(:bring?).with(:acronym).returns(false)
+    ontology.stubs(:bring?).with(:provisionalClasses).returns(false)
+    ontology.stubs(:acronym).returns("BOOM")
+    ontology.stubs(:provisionalClasses).returns([])
+    ontology.expects(:unindex_by_acronym).with(false)
+
+    language = mock("language")
+    language.expects(:skos?).returns(false)
+
+    submission = mock("submission")
+    submission.stubs(:bring?).with(:ontology).returns(false)
+    submission.stubs(:ontology).returns(ontology)
+    submission.stubs(:csv_path).returns("/tmp/boom-classes.csv")
+    submission.stubs(:loaded_attributes).returns([:hasOntologyLanguage])
+    submission.stubs(:hasOntologyLanguage).returns(language)
+    submission.stubs(:class_count).returns(3)
+    submission.stubs(:id).returns(RDF::URI.new("http://example.org/submissions/boom"))
+
+    c1 = stub("c1", id: RDF::URI.new("http://example.org/c/1"), indexable_object: { id: "1" })
+    page_one = [c1]
+
+    page_two_scope = Object.new
+    page_two_scope.define_singleton_method(:all) { raise "boom fetching page 2" }
+
+    csv_writer = mock("csv-writer")
+    csv_writer.stubs(:open)
+    csv_writer.stubs(:write_class)
+    csv_writer.stubs(:close)
+    LinkedData::Utils::OntologyCSVWriter.expects(:new).returns(csv_writer)
+
+    first_page_scope = mock("first-page-scope")
+    first_page_scope.expects(:all).returns(page_one)
+
+    paging = mock("class-paging")
+    paging.expects(:include).with(:unmapped).returns(paging)
+    paging.expects(:aggregate).with(:count, :children).returns(paging)
+    paging.expects(:page).with(0, 2).returns(paging)
+    paging.expects(:page_count_set).with(3)
+    paging.expects(:page).with(1, 2).returns(first_page_scope)
+    paging.expects(:page).with(2, 2).returns(page_two_scope)
+    paging.stubs(:equivalent_predicates).returns({})
+    LinkedData::Models::Class.expects(:in).with(submission).returns(paging)
+    LinkedData::Models::Class.stubs(:map_attributes)
+
+    search_client = mock("search-client")
+    search_client.stubs(:index_document)
+    LinkedData::Models::Class.stubs(:search_client).returns(search_client)
+
+    indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
+    indexer.stubs(:compute_ancestors_map).returns({})
+
+    error = assert_raises(RuntimeError) do
+      indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, page_size: 2)
+    end
+    assert_match(/boom fetching page 2/, error.message)
+  ensure
+    LinkedData::Models::Class.ancestors_cache = nil
+  end
+
+  def test_index_terms_multi_page_prefetch_indexes_same_complete_set
+    # Real end-to-end paging: index the same ontology once as a single page
+    # (reference) and once with a tiny page_size that forces many prefetched
+    # pages. The background fetch runs against the real SPARQL client + Solr.
+    # Both runs must produce the identical, complete document set — proving the
+    # concurrent prefetch drops no pages and duplicates none.
+    submission_parse("BRO", "BRO Ontology",
+                     "./test/data/ontology_files/BRO_v3.5.owl", 1,
+                     process_rdf: true, extract_metadata: false, generate_missing_labels: false,
+                     index_search: false, index_properties: false)
+
+    sub = LinkedData::Models::Ontology.find("BRO").first.latest_submission(status: :rdf)
+    sub.bring_remaining
+    indexer = LinkedData::Services::OntologySubmissionIndexer.new(sub)
+
+    indexer.send(:index, Logger.new(TestLogFile.new),
+                 commit: true, optimize: false, commit_within: nil,
+                 generate_csv: false, unindex_existing: true, page_size: 100_000)
+    reference = LinkedData::Models::Class.search("*:*", { fq: "submissionAcronym:BRO", rows: 0 })["response"]["numFound"]
+    assert_operator reference, :>, 5, "fixture must span multiple pages at page_size=5"
+
+    indexer.send(:index, Logger.new(TestLogFile.new),
+                 commit: true, optimize: false, commit_within: nil,
+                 generate_csv: false, unindex_existing: true, page_size: 5)
+    prefetched = LinkedData::Models::Class.search("*:*", { fq: "submissionAcronym:BRO", rows: 0 })["response"]["numFound"]
+
+    assert_equal reference, prefetched,
+                 "multi-page prefetch must index the same complete set as a single page"
   end
 
   def test_skos_submission_without_skos_concept_processes_without_error

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1400,7 +1400,7 @@ eos
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})
 
-    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, page_size: 2500)
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false)
   ensure
     LinkedData::Models::Class.ancestors_cache = nil
   end
@@ -1464,7 +1464,7 @@ eos
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})
 
-    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, page_size: 2500)
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false)
   ensure
     LinkedData::Models::Class.ancestors_cache = nil
   end
@@ -1500,7 +1500,7 @@ eos
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})
 
-    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, commit_within: nil, generate_csv: false, page_size: 2500)
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, commit_within: nil, generate_csv: false)
   ensure
     LinkedData::Models::Class.ancestors_cache = nil
   end
@@ -1541,242 +1541,9 @@ eos
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})
 
-    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, unindex_existing: false, page_size: 2500)
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, unindex_existing: false)
   ensure
     LinkedData::Models::Class.ancestors_cache = nil
-  end
-
-  def test_index_terms_indexes_all_pages_in_order
-    ontology = mock("ontology")
-    ontology.stubs(:bring?).with(:acronym).returns(false)
-    ontology.stubs(:bring?).with(:provisionalClasses).returns(false)
-    ontology.stubs(:acronym).returns("ORDER")
-    ontology.stubs(:provisionalClasses).returns([])
-    ontology.expects(:unindex_by_acronym).with(false)
-
-    language = mock("language")
-    language.expects(:skos?).returns(false)
-
-    submission = mock("submission")
-    submission.stubs(:bring?).with(:ontology).returns(false)
-    submission.stubs(:ontology).returns(ontology)
-    submission.stubs(:csv_path).returns("/tmp/order-classes.csv")
-    submission.stubs(:loaded_attributes).returns([:hasOntologyLanguage])
-    submission.stubs(:hasOntologyLanguage).returns(language)
-    submission.stubs(:class_count).returns(5)
-    submission.stubs(:id).returns(RDF::URI.new("http://example.org/submissions/order"))
-
-    classes = (1..5).map do |i|
-      stub("c#{i}", id: RDF::URI.new("http://example.org/c/#{i}"), indexable_object: { id: i.to_s })
-    end
-    page_one   = [classes[0], classes[1]]
-    page_two   = [classes[2], classes[3]]
-    page_three = [classes[4]]
-
-    csv_writer = mock("csv-writer")
-    csv_writer.expects(:open).with(ontology, "/tmp/order-classes.csv")
-    csv_writer.stubs(:write_class)
-    csv_writer.expects(:close)
-    LinkedData::Utils::OntologyCSVWriter.expects(:new).returns(csv_writer)
-
-    scope_one   = mock("scope-1"); scope_one.expects(:all).returns(page_one)
-    scope_two   = mock("scope-2"); scope_two.expects(:all).returns(page_two)
-    scope_three = mock("scope-3"); scope_three.expects(:all).returns(page_three)
-
-    paging = mock("class-paging")
-    paging.expects(:include).with(:unmapped).returns(paging)
-    paging.expects(:aggregate).with(:count, :children).returns(paging)
-    paging.expects(:page).with(0, 2).returns(paging)
-    paging.expects(:page_count_set).with(5)
-    paging.expects(:page).with(1, 2).once.returns(scope_one)
-    paging.expects(:page).with(2, 2).once.returns(scope_two)
-    paging.expects(:page).with(3, 2).once.returns(scope_three)
-    paging.stubs(:equivalent_predicates).returns({})
-    LinkedData::Models::Class.expects(:in).with(submission).returns(paging)
-
-    classes.each do |c|
-      LinkedData::Models::Class.expects(:map_attributes).with(c, {}, include_languages: true)
-    end
-
-    index_seq = sequence("index-order")
-    search_client = mock("search-client")
-    search_client.expects(:index_document).with([{ id: "1" }, { id: "2" }], commit: false, commit_within: nil).in_sequence(index_seq)
-    search_client.expects(:index_document).with([{ id: "3" }, { id: "4" }], commit: false, commit_within: nil).in_sequence(index_seq)
-    search_client.expects(:index_document).with([{ id: "5" }], commit: false, commit_within: nil).in_sequence(index_seq)
-    LinkedData::Models::Class.stubs(:search_client).returns(search_client)
-
-    indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
-    indexer.stubs(:compute_ancestors_map).returns({})
-
-    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, page_size: 2)
-  ensure
-    LinkedData::Models::Class.ancestors_cache = nil
-  end
-
-  def test_index_terms_sets_requested_lang_all_in_background_fetch_thread
-    # RequestStore is thread-local. The page-prefetch thread must set
-    # requested_lang = :ALL itself; otherwise the background fetch would run
-    # under the wrong language and drop multilingual values. This asserts the
-    # value observed *during the background fetch* is :ALL.
-    ontology = mock("ontology")
-    ontology.stubs(:bring?).with(:acronym).returns(false)
-    ontology.stubs(:bring?).with(:provisionalClasses).returns(false)
-    ontology.stubs(:acronym).returns("LANG")
-    ontology.stubs(:provisionalClasses).returns([])
-    ontology.expects(:unindex_by_acronym).with(false)
-
-    language = mock("language")
-    language.expects(:skos?).returns(false)
-
-    submission = mock("submission")
-    submission.stubs(:bring?).with(:ontology).returns(false)
-    submission.stubs(:ontology).returns(ontology)
-    submission.stubs(:csv_path).returns("/tmp/lang-classes.csv")
-    submission.stubs(:loaded_attributes).returns([:hasOntologyLanguage])
-    submission.stubs(:hasOntologyLanguage).returns(language)
-    submission.stubs(:class_count).returns(3)
-    submission.stubs(:id).returns(RDF::URI.new("http://example.org/submissions/lang"))
-
-    c1 = stub("c1", id: RDF::URI.new("http://example.org/c/1"), indexable_object: { id: "1" })
-    c2 = stub("c2", id: RDF::URI.new("http://example.org/c/2"), indexable_object: { id: "2" })
-    page_one = [c1]
-    page_two = [c2]
-
-    captured_langs = Queue.new
-    # page 2 is the one fetched on the background thread; capture the
-    # thread-local lang observed when its fetch executes.
-    page_two_scope = Object.new
-    page_two_scope.define_singleton_method(:all) do
-      captured_langs << RequestStore.store[:requested_lang]
-      page_two
-    end
-
-    csv_writer = mock("csv-writer")
-    csv_writer.stubs(:open)
-    csv_writer.stubs(:write_class)
-    csv_writer.stubs(:close)
-    LinkedData::Utils::OntologyCSVWriter.expects(:new).returns(csv_writer)
-
-    first_page_scope = mock("first-page-scope")
-    first_page_scope.expects(:all).returns(page_one)
-
-    paging = mock("class-paging")
-    paging.expects(:include).with(:unmapped).returns(paging)
-    paging.expects(:aggregate).with(:count, :children).returns(paging)
-    paging.expects(:page).with(0, 2).returns(paging)
-    paging.expects(:page_count_set).with(3)
-    paging.expects(:page).with(1, 2).returns(first_page_scope)
-    paging.expects(:page).with(2, 2).returns(page_two_scope)
-    paging.stubs(:equivalent_predicates).returns({})
-    LinkedData::Models::Class.expects(:in).with(submission).returns(paging)
-    LinkedData::Models::Class.stubs(:map_attributes)
-
-    search_client = mock("search-client")
-    search_client.stubs(:index_document)
-    LinkedData::Models::Class.stubs(:search_client).returns(search_client)
-
-    indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
-    indexer.stubs(:compute_ancestors_map).returns({})
-
-    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, page_size: 2)
-
-    langs = []
-    langs << captured_langs.pop until captured_langs.empty?
-    assert_includes langs, :ALL, "background page fetch must run with requested_lang = :ALL"
-  ensure
-    LinkedData::Models::Class.ancestors_cache = nil
-  end
-
-  def test_index_terms_reraises_background_page_fetch_errors
-    # A failed page fetch must surface, not silently drop the remaining pages.
-    ontology = mock("ontology")
-    ontology.stubs(:bring?).with(:acronym).returns(false)
-    ontology.stubs(:bring?).with(:provisionalClasses).returns(false)
-    ontology.stubs(:acronym).returns("BOOM")
-    ontology.stubs(:provisionalClasses).returns([])
-    ontology.expects(:unindex_by_acronym).with(false)
-
-    language = mock("language")
-    language.expects(:skos?).returns(false)
-
-    submission = mock("submission")
-    submission.stubs(:bring?).with(:ontology).returns(false)
-    submission.stubs(:ontology).returns(ontology)
-    submission.stubs(:csv_path).returns("/tmp/boom-classes.csv")
-    submission.stubs(:loaded_attributes).returns([:hasOntologyLanguage])
-    submission.stubs(:hasOntologyLanguage).returns(language)
-    submission.stubs(:class_count).returns(3)
-    submission.stubs(:id).returns(RDF::URI.new("http://example.org/submissions/boom"))
-
-    c1 = stub("c1", id: RDF::URI.new("http://example.org/c/1"), indexable_object: { id: "1" })
-    page_one = [c1]
-
-    page_two_scope = Object.new
-    page_two_scope.define_singleton_method(:all) { raise "boom fetching page 2" }
-
-    csv_writer = mock("csv-writer")
-    csv_writer.stubs(:open)
-    csv_writer.stubs(:write_class)
-    csv_writer.stubs(:close)
-    LinkedData::Utils::OntologyCSVWriter.expects(:new).returns(csv_writer)
-
-    first_page_scope = mock("first-page-scope")
-    first_page_scope.expects(:all).returns(page_one)
-
-    paging = mock("class-paging")
-    paging.expects(:include).with(:unmapped).returns(paging)
-    paging.expects(:aggregate).with(:count, :children).returns(paging)
-    paging.expects(:page).with(0, 2).returns(paging)
-    paging.expects(:page_count_set).with(3)
-    paging.expects(:page).with(1, 2).returns(first_page_scope)
-    paging.expects(:page).with(2, 2).returns(page_two_scope)
-    paging.stubs(:equivalent_predicates).returns({})
-    LinkedData::Models::Class.expects(:in).with(submission).returns(paging)
-    LinkedData::Models::Class.stubs(:map_attributes)
-
-    search_client = mock("search-client")
-    search_client.stubs(:index_document)
-    LinkedData::Models::Class.stubs(:search_client).returns(search_client)
-
-    indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
-    indexer.stubs(:compute_ancestors_map).returns({})
-
-    error = assert_raises(RuntimeError) do
-      indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, page_size: 2)
-    end
-    assert_match(/boom fetching page 2/, error.message)
-  ensure
-    LinkedData::Models::Class.ancestors_cache = nil
-  end
-
-  def test_index_terms_multi_page_prefetch_indexes_same_complete_set
-    # Real end-to-end paging: index the same ontology once as a single page
-    # (reference) and once with a tiny page_size that forces many prefetched
-    # pages. The background fetch runs against the real SPARQL client + Solr.
-    # Both runs must produce the identical, complete document set — proving the
-    # concurrent prefetch drops no pages and duplicates none.
-    submission_parse("BRO", "BRO Ontology",
-                     "./test/data/ontology_files/BRO_v3.5.owl", 1,
-                     process_rdf: true, extract_metadata: false, generate_missing_labels: false,
-                     index_search: false, index_properties: false)
-
-    sub = LinkedData::Models::Ontology.find("BRO").first.latest_submission(status: :rdf)
-    sub.bring_remaining
-    indexer = LinkedData::Services::OntologySubmissionIndexer.new(sub)
-
-    indexer.send(:index, Logger.new(TestLogFile.new),
-                 commit: true, optimize: false, commit_within: nil,
-                 generate_csv: false, unindex_existing: true, page_size: 100_000)
-    reference = LinkedData::Models::Class.search("*:*", { fq: "submissionAcronym:BRO", rows: 0 })["response"]["numFound"]
-    assert_operator reference, :>, 5, "fixture must span multiple pages at page_size=5"
-
-    indexer.send(:index, Logger.new(TestLogFile.new),
-                 commit: true, optimize: false, commit_within: nil,
-                 generate_csv: false, unindex_existing: true, page_size: 5)
-    prefetched = LinkedData::Models::Class.search("*:*", { fq: "submissionAcronym:BRO", rows: 0 })["response"]["numFound"]
-
-    assert_equal reference, prefetched,
-                 "multi-page prefetch must index the same complete set as a single page"
   end
 
   def test_skos_submission_without_skos_concept_processes_without_error

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1469,6 +1469,42 @@ eos
     LinkedData::Models::Class.ancestors_cache = nil
   end
 
+  def test_index_terms_can_skip_csv_generation
+    ontology = mock("ontology")
+    ontology.stubs(:bring?).with(:acronym).returns(false)
+    ontology.stubs(:bring?).with(:provisionalClasses).returns(false)
+    ontology.stubs(:acronym).returns("NOCSV")
+    ontology.stubs(:provisionalClasses).returns([])
+    ontology.expects(:unindex_by_acronym).with(false)
+
+    submission = mock("submission")
+    submission.stubs(:bring?).with(:ontology).returns(false)
+    submission.stubs(:ontology).returns(ontology)
+    submission.stubs(:loaded_attributes).returns([:hasOntologyLanguage])
+    submission.stubs(:hasOntologyLanguage).returns(stub(skos?: true))
+    submission.stubs(:id).returns(RDF::URI.new("http://example.org/submissions/nocsv"))
+
+    empty_page = []
+    empty_page.define_singleton_method(:total_pages) { 0 }
+    empty_page.define_singleton_method(:next?) { false }
+
+    paging = mock("class-paging")
+    paging.expects(:include).with(:unmapped).returns(paging)
+    paging.expects(:aggregate).with(:count, :children).returns(paging)
+    paging.expects(:page).with(0, 2500).returns(paging)
+    paging.expects(:page).with(1, 2500).returns(paging)
+    paging.expects(:all).returns(empty_page)
+    LinkedData::Models::Class.expects(:in).with(submission).returns(paging)
+    LinkedData::Utils::OntologyCSVWriter.expects(:new).never
+
+    indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
+    indexer.stubs(:compute_ancestors_map).returns({})
+
+    indexer.send(:index, Logger.new(TestLogFile.new), false, false, nil, false)
+  ensure
+    LinkedData::Models::Class.ancestors_cache = nil
+  end
+
   def test_skos_submission_without_skos_concept_processes_without_error
     # Regression for GH-274: SKOS submissions with no skos:Concept previously entered the
     # retry path and failed during missing-label generation because the CSV class_count

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1400,7 +1400,7 @@ eos
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})
 
-    indexer.send(:index, Logger.new(TestLogFile.new), false, false)
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false)
   ensure
     LinkedData::Models::Class.ancestors_cache = nil
   end
@@ -1464,7 +1464,7 @@ eos
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})
 
-    indexer.send(:index, Logger.new(TestLogFile.new), false, false)
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false)
   ensure
     LinkedData::Models::Class.ancestors_cache = nil
   end
@@ -1500,7 +1500,7 @@ eos
     indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
     indexer.stubs(:compute_ancestors_map).returns({})
 
-    indexer.send(:index, Logger.new(TestLogFile.new), false, false, nil, false)
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, commit_within: nil, generate_csv: false)
   ensure
     LinkedData::Models::Class.ancestors_cache = nil
   end

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1505,6 +1505,47 @@ eos
     LinkedData::Models::Class.ancestors_cache = nil
   end
 
+  def test_index_terms_skips_unindex_by_acronym_when_target_is_fresh
+    ontology = mock("ontology")
+    ontology.stubs(:bring?).with(:acronym).returns(false)
+    ontology.stubs(:bring?).with(:provisionalClasses).returns(false)
+    ontology.stubs(:acronym).returns("FRESH")
+    ontology.stubs(:provisionalClasses).returns([])
+    ontology.expects(:unindex_by_acronym).never
+
+    submission = mock("submission")
+    submission.stubs(:bring?).with(:ontology).returns(false)
+    submission.stubs(:ontology).returns(ontology)
+    submission.stubs(:csv_path).returns("/tmp/fresh-classes.csv")
+    submission.stubs(:loaded_attributes).returns([:hasOntologyLanguage])
+    submission.stubs(:hasOntologyLanguage).returns(stub(skos?: true))
+    submission.stubs(:id).returns(RDF::URI.new("http://example.org/submissions/fresh"))
+
+    csv_writer = mock("csv-writer")
+    csv_writer.expects(:open).with(ontology, "/tmp/fresh-classes.csv")
+    csv_writer.expects(:close)
+    LinkedData::Utils::OntologyCSVWriter.expects(:new).returns(csv_writer)
+
+    empty_page = []
+    empty_page.define_singleton_method(:total_pages) { 0 }
+    empty_page.define_singleton_method(:next?) { false }
+
+    paging = mock("class-paging")
+    paging.expects(:include).with(:unmapped).returns(paging)
+    paging.expects(:aggregate).with(:count, :children).returns(paging)
+    paging.expects(:page).with(0, 2500).returns(paging)
+    paging.expects(:page).with(1, 2500).returns(paging)
+    paging.expects(:all).returns(empty_page)
+    LinkedData::Models::Class.expects(:in).with(submission).returns(paging)
+
+    indexer = LinkedData::Services::OntologySubmissionIndexer.new(submission)
+    indexer.stubs(:compute_ancestors_map).returns({})
+
+    indexer.send(:index, Logger.new(TestLogFile.new), commit: false, optimize: false, unindex_existing: false)
+  ensure
+    LinkedData::Models::Class.ancestors_cache = nil
+  end
+
   def test_skos_submission_without_skos_concept_processes_without_error
     # Regression for GH-274: SKOS submissions with no skos:Concept previously entered the
     # retry path and failed during missing-label generation because the CSV class_count

--- a/test/models/test_search.rb
+++ b/test/models/test_search.rb
@@ -22,8 +22,8 @@ class TestSearch < LinkedData::TestCase
 
     assert_equal %w[prefLabelExact synonymExact], exact_fields.map { |field| field[:name] }.sort
     assert_equal %w[prefLabelExact_* synonymExact_*], exact_dynamic_fields.map { |field| field[:name] }.sort
-    assert exact_fields.all? { |field| field[:type] == 'string_ci' }
-    assert exact_dynamic_fields.all? { |field| field[:type] == 'string_ci' }
+    assert exact_fields.all? { |field| field[:type] == 'string_ci_exact' }
+    assert exact_dynamic_fields.all? { |field| field[:type] == 'string_ci_exact' }
     refute_nil ontology_rank_field
     assert_equal 'pfloat', ontology_rank_field[:type]
     assert_equal '0.0', ontology_rank_field[:default]

--- a/test/models/test_search.rb
+++ b/test/models/test_search.rb
@@ -12,6 +12,36 @@ class TestSearch < LinkedData::TestCase
     self.class.after_suite
   end
 
+  def test_term_search_exact_fields_are_case_insensitive
+    schema_generator = SOLR::SolrSchemaGenerator.new
+    LinkedData::Models::Class.index_schema(schema_generator)
+
+    exact_fields = schema_generator.fields_to_add.select { |field| %w[prefLabelExact synonymExact].include?(field[:name]) }
+    exact_dynamic_fields = schema_generator.dynamic_fields_to_add.select { |field| %w[prefLabelExact_* synonymExact_*].include?(field[:name]) }
+    ontology_rank_field = schema_generator.fields_to_add.find { |field| field[:name] == 'ontologyRank' }
+
+    assert_equal %w[prefLabelExact synonymExact], exact_fields.map { |field| field[:name] }.sort
+    assert_equal %w[prefLabelExact_* synonymExact_*], exact_dynamic_fields.map { |field| field[:name] }.sort
+    assert exact_fields.all? { |field| field[:type] == 'string_ci' }
+    assert exact_dynamic_fields.all? { |field| field[:type] == 'string_ci' }
+    refute_nil ontology_rank_field
+    assert_equal 'pfloat', ontology_rank_field[:type]
+    assert_equal '0.0', ontology_rank_field[:default]
+  end
+
+  def test_ontology_rank_for_index_uses_normalized_score
+    begin
+      LinkedData::Models::Class.instance_variable_set(:@ontology_rank_cache, {
+        'RANKED' => { normalizedScore: 0.884 }
+      })
+
+      assert_equal 0.884, LinkedData::Models::Class.ontology_rank_for_index('RANKED')
+      assert_equal 0.0, LinkedData::Models::Class.ontology_rank_for_index('UNRANKED')
+    ensure
+      LinkedData::Models::Class.reset_ontology_rank_cache
+    end
+  end
+
   def test_search_ontology
     _, _, created_ontologies = create_ontologies_and_submissions({
                                                                     process_submission: true,


### PR DESCRIPTION
## Summary

Data-layer companion for fixing the term-search ranking regression on `ncbo/ontologies_api`. Ships the Solr schema and indexer changes that enable BioPortal ontology rank to participate in term-search scoring before pagination (ncbo/ontologies_api#230), and pairs them with several term-indexing improvements that this branch needed along the way.

## What this PR does

### Search ranking infrastructure (the core change)

- **Schema** (`lib/ontologies_linked_data/models/class.rb`): adds the `ontologyRank` Solr field (`pfloat`, indexed, stored, `default: 0.0`).
- **Schema**: switches `prefLabelExact` and `synonymExact` (plus their `*_*` dynamic language variants) from `string` to `string_ci`, restoring case-insensitive exact match that regressed during the schemaless migration.
- **Indexer**: populates `ontologyRank` per class doc from `LinkedData::Models::Ontology.rank[:normalizedScore]`, cached for the duration of an indexing run (class-level cache reset by `OntologySubmissionIndexer`).

### Term-indexing improvements (paired but independently useful)

- Skip `unindex_by_acronym` when indexing into a fresh collection.
- Allow term-only indexing without CSV generation.
- Honor disabled index commits during processing.
- Use keyword options for the term indexer.
- Restore `requested_lang` after indexing to prevent cross-ontology leakage.
- Guard against nil submission after metadata extraction failure.
- Bump `goo` pin to `684fbe06`.

## Dependencies

- [ ] **ncbo/goo PR ncbo/goo#187** — required. Adds the alias-guard fix in `SolrConnector#init` that prevents `CREATEALIAS` from silently shadowing an existing collection.

## Deploy coordination

This branch ships the schema for `ontologyRank` and the indexer that populates it. The downstream `ontologies_api` change that consumes the field in Solr scoring needs the term-search collection rebuilt under this schema before it can deploy. Coordinated cutover:

1. Build the new term-search collection under this schema (full reindex).
2. Flip the `term_search` alias to the new collection.
3. Deploy the `ontologies_api` change together with this branch.

## Out of scope

- The term-search ranking algorithm change (`boost=sum(ontologyRank,1)` in edismax params, removal of post-hoc Ruby sort) — lives in the corresponding `ncbo/ontologies_api` PR.
- Property-search has a parallel pattern (separate Solr collection, separate indexer); tracked as ncbo/ontologies_api#231.

