### PR TITLE
Feature: add RankSolrPropagator to refresh Solr ontologyRank from Redis

### DIFF
--- a/lib/ontologies_linked_data/services/rank_solr_propagator.rb
+++ b/lib/ontologies_linked_data/services/rank_solr_propagator.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module LinkedData
+  module Services
+    # Propagates the current ontology rank values into the denormalized
+    # `ontologyRank` field on every class document in the Solr `term_search`
+    # collection. Pure Redis -> Solr propagation: no analytics/UMLS
+    # recomputation happens here (that is the job of ncbo_cron's
+    # NcboCron::Models::OntologyRank, which calls this immediately after it
+    # writes the freshly computed rank to Redis).
+    #
+    # Rank is read through LinkedData::Models::Ontology.rank (the same source
+    # the indexer uses), which derives normalizedScore from the Redis-stored
+    # bioportalScore/umlsScore using the configured weights.
+    #
+    # Updates use true Solr atomic updates ({ id, ontologyRank: { set: score } })
+    # so no per-class triplestore read is needed.
+    #
+    # See https://github.com/ncbo/ncbo_cron/issues/132
+    class RankSolrPropagator
+      DEFAULT_BATCH_SIZE = 1000
+
+      def initialize(logger: nil, batch_size: DEFAULT_BATCH_SIZE)
+        @logger = logger || Logger.new($stdout)
+        @batch_size = batch_size
+      end
+
+      # Reads the rank map and writes each ontology's normalizedScore onto all
+      # of its term_search docs. Returns the count of ontologies whose docs were
+      # updated.
+      def propagate(rank_map = nil)
+        rank_map ||= LinkedData::Models::Ontology.rank
+
+        if rank_map.nil? || rank_map.empty?
+          @logger.warn('RankSolrPropagator: empty rank map; nothing to propagate')
+          return 0
+        end
+
+        updated = 0
+        rank_map.each do |acronym, rank_info|
+          score = rank_info[:normalizedScore].to_f
+          count = update_ontology_rank(acronym, score)
+          @logger.info("RankSolrPropagator: #{acronym} rank=#{score} (#{count} docs)")
+          updated += 1 if count.positive?
+        end
+
+        LinkedData::Models::Class.indexCommit(nil)
+        @logger.info("RankSolrPropagator: committed; updated #{updated} ontologies")
+        updated
+      end
+
+      private
+
+      # Cursor-scans all term_search docs for the acronym and issues batched
+      # atomic updates to ontologyRank. Returns the number of docs updated.
+      def update_ontology_rank(acronym, score)
+        cursor = '*'
+        total = 0
+        query = "submissionAcronym:\"#{acronym}\""
+
+        loop do
+          resp = LinkedData::Models::Class.search(
+            query,
+            { fl: 'id', rows: @batch_size, sort: 'id asc', cursorMark: cursor }
+          )
+          docs = resp.dig('response', 'docs') || []
+
+          unless docs.empty?
+            batch = docs.map { |d| { id: d['id'], ontologyRank: { set: score } } }
+            LinkedData::Models::Class.search_client.index_document(batch, commit: false)
+            total += batch.size
+          end
+
+          next_cursor = resp['nextCursorMark']
+          break if next_cursor.nil? || next_cursor == cursor
+
+          cursor = next_cursor
+        end
+
+        total
+      end
+    end
+  end
+end

--- a/test/services/test_rank_solr_propagator.rb
+++ b/test/services/test_rank_solr_propagator.rb
@@ -1,0 +1,78 @@
+require_relative '../models/test_ontology_common'
+require 'mocha/minitest'
+
+class TestRankSolrPropagator < LinkedData::TestOntologyCommon
+  ACRONYM = 'BRO'
+
+  def self.after_suite
+    backend_4s_delete
+    LinkedData::Models::Class.indexClear
+    LinkedData::Models::Class.indexCommit(nil)
+  end
+
+  def setup
+    self.class.after_suite
+    # Index a small ontology's terms into the real local term_search collection.
+    submission_parse(ACRONYM, 'BRO Ontology',
+                     './test/data/ontology_files/BRO_v3.5.owl', 1,
+                     process_rdf: true, extract_metadata: false,
+                     generate_missing_labels: false,
+                     index_search: true, index_properties: false)
+  end
+
+  def teardown
+    self.class.after_suite
+  end
+
+  def term_docs
+    LinkedData::Models::Class.search(
+      '*:*',
+      { fq: "submissionAcronym:#{ACRONYM}", fl: 'id,ontologyRank', rows: 10_000 }
+    )['response']['docs']
+  end
+
+  def test_propagate_writes_normalized_score_to_all_term_docs
+    docs_before = term_docs
+    refute_empty docs_before, 'expected BRO terms to be indexed in term_search'
+
+    LinkedData::Models::Ontology.stubs(:rank).returns(
+      { ACRONYM => { bioportalScore: 0.5, umlsScore: 0.0, normalizedScore: 0.642 } }
+    )
+
+    updated = LinkedData::Services::RankSolrPropagator.new.propagate
+    assert_equal 1, updated
+
+    docs_after = term_docs
+    assert_equal docs_before.size, docs_after.size
+    docs_after.each do |doc|
+      assert_in_delta 0.642, doc['ontologyRank'].to_f, 0.0001,
+                      "doc #{doc['id']} should have the propagated rank"
+    end
+  end
+
+  def test_propagate_preserves_searchable_fields
+    # A real term search works before propagation.
+    before = LinkedData::Models::Class.search(
+      'prefLabel:Activity', { fq: "submissionAcronym:#{ACRONYM}", rows: 80 }
+    )['response']['numFound']
+    refute_equal 0, before, 'expected a prefLabel match before propagation'
+
+    LinkedData::Models::Ontology.stubs(:rank).returns(
+      { ACRONYM => { bioportalScore: 0.5, umlsScore: 0.0, normalizedScore: 0.642 } }
+    )
+    LinkedData::Services::RankSolrPropagator.new.propagate
+
+    # The same search still works after atomic updates (copyField targets and
+    # stored fields survived the partial update).
+    after = LinkedData::Models::Class.search(
+      'prefLabel:Activity', { fq: "submissionAcronym:#{ACRONYM}", rows: 80 }
+    )['response']['numFound']
+    assert_equal before, after,
+                 'atomic update must not drop searchable content'
+  end
+
+  def test_propagate_returns_zero_for_empty_rank_map
+    LinkedData::Models::Ontology.stubs(:rank).returns({})
+    assert_equal 0, LinkedData::Services::RankSolrPropagator.new.propagate
+  end
+end


### PR DESCRIPTION
## Summary

Adds `LinkedData::Services::RankSolrPropagator`, the ontology_linked_data part of keeping the denormalized `ontologyRank` field on `term_search` class documents in sync with the weekly-recomputed Redis rank. Today that field is captured only at indexing time, so an ontology whose popularity grows after its last submission keeps a stale rank — worst case, a brand-new ontology stays at rank 0 — until it is re-indexed. The propagator reads the current rank map via `LinkedData::Models::Ontology.rank` (the same source the indexer uses, which derives `normalizedScore` from the Redis-stored `bioportalScore`/`umlsScore`) and writes each ontology's score onto all of its `term_search` docs using Solr atomic updates, with no per-class triplestore reads.

Addresses ncbo/ncbo_cron#132.

## What this does

- New `lib/ontologies_linked_data/services/rank_solr_propagator.rb`: cursor-scans `term_search` for each acronym (by `submissionAcronym`), issues batched atomic `{ id, ontologyRank: { set: score } }` updates, and ends with a single commit.
- New `test/services/test_rank_solr_propagator.rb`: indexes a small ontology and verifies that every doc receives the propagated score, that a normal `prefLabel` search still matches afterward, and that an empty rank map is a no-op.

## Verified

- The atomic update preserves searchable content. The `*Suggest*` fields are `copyField` targets, which Solr regenerates on every atomic update, so updating `ontologyRank` does not require flipping them to `stored: true` or running a full reindex. The preservation test confirms `prefLabel:Activity` still matches after propagation.

## Scope

- This PR is the data layer only. The scheduling — calling the propagator at the end of the weekly rank job (`NcboCron::Models::OntologyRank#run`) — lives in a companion `ncbo_cron` PR that depends on this one merging first.