### PR TITLE
Class tree performance: remove per-node N+1 queries (build + serialize)

### DIFF
--- a/lib/ontologies_linked_data/concerns/concepts/concept_in_scheme.rb
+++ b/lib/ontologies_linked_data/concerns/concepts/concept_in_scheme.rb
@@ -16,7 +16,13 @@ module LinkedData
 
         def load_is_in_scheme(schemes = [])
           included = schemes.select { |s| inScheme?(s) }
-          included = [self.submission.get_main_concept_scheme] if included.empty? && schemes&.empty?
+          # isInActiveScheme is a SKOS-only concept and is only serialized for
+          # SKOS submissions. Skip the main-concept-scheme lookup for non-SKOS
+          # (OWL/OBO) submissions, where it would run a Scheme query per node
+          # that always returns nothing and is then discarded.
+          if included.empty? && schemes&.empty? && submission.skos?
+            included = [self.submission.get_main_concept_scheme]
+          end
           @isInActiveScheme = included
         end
 

--- a/lib/ontologies_linked_data/concerns/ontology_submissions/skos/skos_submission_schemes.rb
+++ b/lib/ontologies_linked_data/concerns/ontology_submissions/skos/skos_submission_schemes.rb
@@ -10,8 +10,12 @@ module LinkedData
           end
         end
 
+        # Memoized: the tree/paths endpoints resolve isInActiveScheme once per
+        # node, so without this the same SKOS::Scheme query fires ~N times per
+        # request (one triplestore miss + N-1 Redis cache hits). Cache the
+        # result on the submission instance for the life of the request.
         def all_concepts_schemes
-          LinkedData::Models::SKOS::Scheme.in(self).all
+          @all_concepts_schemes ||= LinkedData::Models::SKOS::Scheme.in(self).all
         end
       end
     end

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -96,7 +96,10 @@ module LinkedData
         result_lang = user_languages
 
         if submission
-          submission.bring :naturalLanguage
+          # Guard the load: goo's #bring re-queries every call, and this runs once
+          # per serialized object. Without the guard, a response of N objects sharing
+          # a submission issues N naturalLanguage queries instead of 1.
+          submission.bring(:naturalLanguage) if submission.bring?(:naturalLanguage)
           languages = get_submission_languages(submission.naturalLanguage)
           # intersection of the two arrays , if the requested language is not :all
           result_lang = user_languages == :all ? languages : Array(user_languages) & languages

--- a/test/models/test_class.rb
+++ b/test/models/test_class.rb
@@ -296,6 +296,46 @@ class TestClassModel < LinkedData::TestOntologyCommon
     assert checked > 0, "expected at least one node with a child-count aggregate"
   end
 
+  # N+1 guard for the class-tree endpoint (OWL). Serializing a tree must resolve
+  # the submission's languages once, not once per node -- before the get_languages
+  # `bring?` guard (ncbo/ontologies_linked_data#302) serialization issued ~one
+  # naturalLanguage query per serialized node. Asserts serialization query
+  # fan-out stays sub-linear in node count so the N+1 cannot silently return.
+  def test_bro_tree_serialize_no_n_plus_1
+    if !LinkedData::Models::Ontology.find("BROTEST123").first
+      submission_parse("BROTEST123", "SOME BROTEST Bla", "./test/data/ontology_files/BRO_v3.2.owl", 123,
+                       process_rdf: true, index_search: false,
+                       run_metrics: false, reasoning: true)
+    end
+    os = LinkedData::Models::Ontology.find("BROTEST123").first.latest_submission(status: [:rdf])
+    # The hypermedia links serialized per node need submission.ontology.acronym,
+    # exactly as the controller has it loaded; preload so serialization runs.
+    os.bring(:ontology) if os.bring?(:ontology)
+    os.ontology.bring(:acronym) if os.ontology.bring?(:acronym)
+
+    statistical_Text_Analysis = "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Statistical_Text_Analysis"
+    display_attrs = [:prefLabel, :hasChildren, :children, :obsolete, :subClassOf]
+    cls = LinkedData::Models::Class.find(RDF::URI.new(statistical_Text_Analysis)).in(os).include(display_attrs).first
+    tree_root = cls.tree
+
+    node_count = 0
+    stack = [tree_root]
+    until stack.empty?
+      n = stack.pop
+      node_count += 1
+      stack.concat(n.children)
+    end
+    assert_operator node_count, :>=, 3, "tree too small to be a meaningful N+1 guard"
+
+    serialize_queries = count_sparql_queries do
+      LinkedData::Serializers::JSON.serialize([tree_root], only: display_attrs)
+    end
+
+    assert_operator serialize_queries, :<, node_count,
+      "serialization issued #{serialize_queries} SPARQL queries for #{node_count} tree nodes -- " \
+      "looks like a per-node N+1 (see get_languages guard in ncbo/ontologies_linked_data#302)"
+  end
+
 
   def test_include_ancestors
     if !LinkedData::Models::Ontology.find("BROTEST123").first

--- a/test/models/test_ontology_common.rb
+++ b/test/models/test_ontology_common.rb
@@ -1,8 +1,37 @@
 require_relative "../test_case"
 require 'rack'
 
+# STOPGAP query counter for N+1 regression guards.
+#
+# TODO(de-fork): replace with Goo::TestHelpers.assert_sparql_queries once the
+# de-fork SPARQL query-counting framework lands on the goo branch this app
+# tracks (ncbo/goo `development`). That helper does not exist there yet, so we
+# count Goo::SPARQL::Client#query invocations directly. Inert unless a counting
+# block armed the thread-local, so it adds nothing in normal runs.
+module GooQueryCountSpy
+  def query(*args, **kwargs, &blk)
+    c = Thread.current[:test_goo_query_count]
+    Thread.current[:test_goo_query_count] = c + 1 unless c.nil?
+    super
+  end
+end
+unless Goo::SPARQL::Client.ancestors.include?(GooQueryCountSpy)
+  Goo::SPARQL::Client.prepend(GooQueryCountSpy)
+end
+
 module LinkedData
   class TestOntologyCommon < LinkedData::TestCase
+
+    # Count Goo SPARQL queries (cache hits + store round-trips) issued by the
+    # block. Counts query fan-out -- what an N+1 inflates -- independent of
+    # cache state. See GooQueryCountSpy above.
+    def count_sparql_queries
+      Thread.current[:test_goo_query_count] = 0
+      yield
+      Thread.current[:test_goo_query_count]
+    ensure
+      Thread.current[:test_goo_query_count] = nil
+    end
 
     def create_count_mapping
       count = LinkedData::Models::MappingCount.where.all.length

--- a/test/models/test_skos_submission.rb
+++ b/test/models/test_skos_submission.rb
@@ -182,5 +182,46 @@ SELECT ?children WHERE {
 
     assert seen_target, 'target class not found within its own tree'
   end
+
+  # N+1 guard for the class-tree endpoint (SKOS). Same contract as the OWL guard
+  # in test_class.rb: serializing a tree must resolve the submission's languages
+  # once, not once per node (get_languages `bring?` guard,
+  # ncbo/ontologies_linked_data#302). Asserts serialization query fan-out stays
+  # sub-linear in node count.
+  def test_skos_tree_serialize_no_n_plus_1
+    sub = before_suite
+    sub.bring(:ontology) if sub.bring?(:ontology)
+    sub.ontology.bring(:acronym) if sub.ontology.bring?(:acronym)
+
+    roots = sub.roots
+    roots.each { |r| LinkedData::Models::Class.in(sub).models([r]).include(children: [:prefLabel]).all }
+    # Pick the bushiest root so the target's tree (root + its siblings) has enough
+    # nodes to make the query-count guard meaningful on this small fixture.
+    root = roots.reject { |r| r.children.empty? }.max_by { |r| r.children.length }
+    refute_nil root, 'expected a SKOS root with children'
+    target = LinkedData::Models::Class.find(root.children.first.id).in(sub).first
+    refute_nil target, 'expected a SKOS root with at least one child'
+
+    display_attrs = [:prefLabel, :hasChildren, :children, :obsolete, :subClassOf] +
+                    LinkedData::Models::Class.concept_is_in_attributes
+    tree_root = target.tree
+
+    node_count = 0
+    stack = [tree_root]
+    until stack.empty?
+      n = stack.pop
+      node_count += 1
+      stack.concat(n.children)
+    end
+    assert_operator node_count, :>=, 2, 'tree too small to be a meaningful N+1 guard'
+
+    serialize_queries = count_sparql_queries do
+      LinkedData::Serializers::JSON.serialize([tree_root], only: display_attrs)
+    end
+
+    assert_operator serialize_queries, :<, node_count,
+      "serialization issued #{serialize_queries} SPARQL queries for #{node_count} tree nodes -- " \
+      "looks like a per-node N+1 (see get_languages guard in ncbo/ontologies_linked_data#302)"
+  end
 end
 


### PR DESCRIPTION
Removes two independent per-node N+1 SPARQL patterns on the class tree endpoint. Follow-up to #297 (batch hasChildren resolution). Two separate commits, one per fix.

Query counts measured against staging AG (goo queries per `/classes/:cls/tree`).

## Commit 1 — tree **build**: per-node concept-scheme query · Fixes #303

`load_is_in_scheme` runs per node during build and calls `get_main_concept_scheme` → `all_concepts_schemes` (a SPARQL query). Two issues:

- **No `skos?` guard** — `isInActiveScheme` is SKOS-only and only serialized for SKOS, but non-SKOS (OWL/OBO) submissions still ran a `skos:ConceptScheme` query per node that always returns nothing. Now skipped for them.
- **No memoization** — for genuine SKOS the scheme set is fixed per request but was re-queried per node. Now memoized on the submission.

| Ontology | Type | Build queries before → after |
|---|---|---|
| IOBC | OWL | 669 → 92 |
| AGROVOC | SKOS | 264 → 58 |

Files: `concerns/concepts/concept_in_scheme.rb`, `concerns/ontology_submissions/skos/skos_submission_schemes.rb`

## Commit 2 — JSON **serialize**: per-node naturalLanguage query · Fixes #304

`serializers/json.rb` `get_languages` runs once per serialized object and calls `submission.bring :naturalLanguage`. goo's `bring` re-queries every call, so a response of N objects sharing a submission issued N queries. Guarded with `bring?` (the codebase convention) so it loads once per request.

This is not tree-specific — `get_languages` runs for **every multi-class response** (search, `/children`, `/descendants`, collections), so this helps broadly. It is also the dominant N+1 on large trees.

| Ontology | Type | Nodes | Serialize queries before → after |
|---|---|---|---|
| DDSS | OWL | 2945 | 2830 → 0 |
| AGROVOC | SKOS (multilingual) | 173 | 60 → 0 |

File: `serializers/json.rb`

## Testing

Syntax-checked; query counts verified against staging AG (numbers above). No triplestore-backed unit run yet — please run the class-tree controller tests against a backend before merge, ideally on both a SKOS and an OWL ontology.


## Observable API change (post-merge note)

For **non-SKOS (OWL/OBO)** ontologies, `isInActiveScheme` in class-tree JSON changes from `[null]` to `[]` (the attribute is serialized unconditionally on tree nodes; the skos? gate now skips the scheme lookup instead of producing `[nil]`). This is a correctness improvement, but consumers that count elements or expect the literal `[null]` should be checked. Pinned by `test_owl_load_is_in_scheme_skips_scheme_query` (139c67eb).

Follow-up 139c67eb on develop also recalibrated these guards after mutation testing: the serializer bounds are now small constants (the `< node_count` bound passed on OWL even with the fix reverted), and the build-phase fix (#303) gained its own guards.
