### PR TITLE
Perf: Limit mapping count sleep to 4store

### DIFF
--- a/lib/ontologies_linked_data/mappings/mappings.rb
+++ b/lib/ontologies_linked_data/mappings/mappings.rb
@@ -68,7 +68,7 @@ module LinkedData
               "Retrieved #{s_total} records for #{acro} in #{Time.now - t0} seconds.")
           logger.flush
         end
-        sleep(5)
+        sleep(5) if Goo.backend_4s?
       end
 
       if enable_debug

--- a/test/models/test_mapping_counts_sleep.rb
+++ b/test/models/test_mapping_counts_sleep.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative '../test_case'
+require 'mocha/minitest'
+
+class TestMappingCountsSleep < Minitest::Test
+  def setup
+    @submissions = {
+      'TEST1' => Object.new,
+      'TEST2' => Object.new
+    }
+
+    LinkedData::Mappings.stubs(:retrieve_latest_submissions).returns(@submissions)
+    LinkedData::Mappings.stubs(:mapping_ontologies_count).returns({})
+    Goo.stubs(:sparql_query_client)
+  end
+
+  def test_skips_sleep_for_non_4store_backends
+    Goo.stubs(:backend_4s?).returns(false)
+    LinkedData::Mappings.expects(:handle_triple_store_downtime).never
+    LinkedData::Mappings.expects(:sleep).never
+
+    counts = LinkedData::Mappings.mapping_counts
+
+    assert_equal({ 'TEST1' => 0, 'TEST2' => 0 }, counts)
+  end
+
+  def test_preserves_sleep_for_4store
+    Goo.stubs(:backend_4s?).returns(true)
+    LinkedData::Mappings.expects(:handle_triple_store_downtime).twice
+    LinkedData::Mappings.expects(:sleep).with(5).twice
+
+    counts = LinkedData::Mappings.mapping_counts
+
+    assert_equal({ 'TEST1' => 0, 'TEST2' => 0 }, counts)
+  end
+end


### PR DESCRIPTION

## Summary

- skip the fixed five-second per-ontology delay on non-4store backends
- preserve the existing delay and health check on 4store
- add regression coverage for both backend paths

Implements https://github.com/ncbo/ontologies_linked_data/issues/305

## Impact

Non-4store mapping-count runs no longer incur `5 × ontology count` seconds of unnecessary delay. Existing 4store pacing remains unchanged.

## Verification

- `bundle exec ruby -Itest test/models/test_mapping_counts_sleep.rb` — 2 runs, 6 assertions
- `bundle exec ruby -Itest test/models/test_mappings.rb` — 5 runs, 196 assertions