### PR TITLE
Perf: Batch load SKOS root classes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: cc806c845c79b707e7a10f44e4959caa15939b8b
+  revision: 752fb6b3fe2ec0ba9417397f3283baeac7a9abfc
   branch: development
   specs:
     goo (0.0.2)

--- a/lib/ontologies_linked_data/concerns/ontology_submissions/skos/skos_submission_roots.rb
+++ b/lib/ontologies_linked_data/concerns/ontology_submissions/skos/skos_submission_roots.rb
@@ -3,18 +3,12 @@ module LinkedData
     module SKOS
       module RootsFetcher
 
-        def skos_roots(concept_schemes, page, paged, pagesize)
-          classes = []
+        def skos_root_ids(concept_schemes, page, paged, pagesize)
           class_ids, count = roots_by_has_top_concept(concept_schemes, page, paged, pagesize)
 
           class_ids, count = roots_by_top_concept_of(concept_schemes, page, paged, pagesize) if class_ids.empty?
 
-          class_ids.each do |id|
-            classes << LinkedData::Models::Class.find(id).in(self).disable_rules.first
-          end
-
-          classes = Goo::Base::Page.new(page, pagesize, count, classes) if paged
-          classes
+          [class_ids, count]
         end
 
         private

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -711,9 +711,11 @@ module LinkedData
 
         skos = self.skos?
         classes = []
+        class_ids = []
+        root_count = 0
 
         if skos
-          classes = skos_roots(concept_schemes, page, paged, pagesize)
+          class_ids, root_count = skos_root_ids(concept_schemes, page, paged, pagesize)
           extra_include += LinkedData::Models::Class.concept_is_in_attributes
         else
           self.ontology.bring(:flat)
@@ -744,7 +746,12 @@ module LinkedData
           end
         end
 
-        where = LinkedData::Models::Class.in(self).models(classes).include(:prefLabel, :definition, :synonym, :obsolete)
+        where = if skos
+                  LinkedData::Models::Class.in(self).ids(class_ids) unless class_ids.empty?
+                else
+                  LinkedData::Models::Class.in(self).models(classes)
+                end
+        where.include(:prefLabel, :definition, :synonym, :obsolete) if where
 
         if extra_include
           %i[prefLabel definition synonym obsolete childrenCount].each do |x|
@@ -767,9 +774,13 @@ module LinkedData
             load_children = [:children]
           end
 
-          where.include(extra_include) if extra_include.length > 0
+          where.include(extra_include) if where && extra_include.length > 0
         end
-        where.all
+        if where
+          loaded_classes = where.all
+          classes = loaded_classes if skos
+        end
+        classes = Goo::Base::Page.new(page, pagesize, root_count, classes) if skos && paged
 
         LinkedData::Models::Class.partially_load_children(classes, 99, self) if load_children.length > 0
 

--- a/test/models/test_skos_submission.rb
+++ b/test/models/test_skos_submission.rb
@@ -104,6 +104,40 @@ SELECT ?children WHERE {
                           'http://www.ebi.ac.uk/efo/EFO_0000324'].sort
   end
 
+  def test_roots_batch_loads_skos_classes
+    sub = before_suite
+    concept_schemes = ['http://www.ebi.ac.uk/efo/skos/EFO_GWAS_view_2',
+                       'http://www.ebi.ac.uk/efo/skos/EFO_GWAS_view']
+
+    roots = nil
+    queries = count_sparql_queries do
+      roots = sub.roots(concept_schemes: concept_schemes)
+    end
+
+    assert_equal 6, roots.length
+    assert_operator queries, :<=, 3,
+      "loading #{roots.length} SKOS roots issued #{queries} SPARQL queries -- " \
+      'looks like per-root class hydration'
+  end
+
+  def test_roots_batch_load_preserves_skos_pagination
+    sub = before_suite
+    concept_scheme = 'http://www.ebi.ac.uk/efo/skos/EFO_GWAS_view'
+
+    roots = sub.roots([], 1, 2, concept_schemes: [concept_scheme])
+
+    assert_instance_of Goo::Base::Page, roots
+    assert_equal 2, roots.length
+    assert_equal 2, roots.total_pages
+  end
+
+  def test_roots_with_no_skos_ids_returns_empty
+    sub = before_suite
+    roots = sub.roots(concept_schemes: ['http://example.org/missing-scheme'])
+
+    assert_empty roots
+  end
+
   def test_roots_of_scheme_collection
     sub = before_suite
 
@@ -241,4 +275,3 @@ SELECT ?children WHERE {
       'submission instance -- per-submission memoization (#302/#303) regressed'
   end
 end
-


### PR DESCRIPTION
## Summary

- Replace per-root `Class.find` hydration with one ID-constrained batch load.
- Load the required root attributes in the same query.
- Preserve SKOS predicate fallback, empty results, pagination, and ordering.
- Advance Goo to the revision containing [#191](https://github.com/ncbo/goo/issues/191).

Fixes [#306](https://github.com/ncbo/ontologies_linked_data/issues/306).

## Performance

Measured through a local API process against the staging AllegroGraph data using AGROVOC `/classes/roots?include=prefLabel` (25 roots).

Five warmups were followed by 50 alternating measured requests per version.

| Version | Median | p95 | Mean |
| --- | ---: | ---: | ---: |
| Before | 454.1 ms | 645.0 ms | 484.5 ms |
| After | 236.9 ms | 298.7 ms | 242.9 ms |
| Improvement | 47.8% | 53.7% | 49.9% |

A second run with 30 requests per version confirmed a 47.6% median improvement. Canonical response bodies were identical before and after.

The six-root regression fixture also reduces Goo SPARQL queries from 9 to 3.

## Verification

- SKOS submission tests: 13 runs, 169 assertions.
- Root-class tests: 2 runs, 73 assertions.
