### PR TITLE
Fix nil crash in paths_to_root at parentless ancestors

### DIFF
--- a/lib/ontologies_linked_data/models/class.rb
+++ b/lib/ontologies_linked_data/models/class.rb
@@ -704,7 +704,14 @@ eos
       end
 
       def traverse_path_to_root(parents, paths, path_i, tree = false, roots = nil)
-        return if (tree && parents.length == 0)
+        # Terminal condition: a class with no parents under the submission's tree
+        # property is the top of this path, so there is nothing left to append.
+        # Callers that pass `roots` (path_to_root / #tree) normally stop earlier in
+        # tree_root? below; callers that do not (the paths_to_root endpoint) rely on
+        # this guard, because the only other sentinel here is owl:Thing -- which
+        # owlapi asserts on top-level OWL classes but which never appears under
+        # skos:broader (SKOS) or metadata:treeView (OBO).
+        return if parents.nil? || parents.empty?
 
         recursions = [path_i]
         recurse_on_path = [false]
@@ -737,13 +744,14 @@ eos
             end
 
             if !p.loaded_attributes.include?(:parents)
-              # fail safely
+              # fail safely -- abandon this path only, the sibling paths in this
+              # frame are unaffected and must still be traversed
               logger = LinkedData::Parser.logger || Logger.new($stderr)
               logger.error("Class #{p.id.to_s} from #{p.submission.id} cannot load parents")
-              return
+              next
             end
 
-            traverse_path_to_root(p.parents.dup, paths, rec_i, tree=tree, roots=roots)
+            traverse_path_to_root((p.parents || []).dup, paths, rec_i, tree=tree, roots=roots)
           end
         end
       end

--- a/test/models/test_class.rb
+++ b/test/models/test_class.rb
@@ -474,32 +474,51 @@ class TestClassModel < LinkedData::TestOntologyCommon
                  LinkedData::Models::Class.tree_view_property(os).to_s,
                  'expected the OBO tree property, otherwise this duplicates the OWL test'
 
-    # Find a class whose own parent has no parents -- one hop is enough to make
-    # the traversal walk into the parentless ancestor.
-    target = nil
+    # Find a class with a parent that itself has no parents -- one hop is enough
+    # to make the traversal walk into the parentless ancestor. Candidates are
+    # sorted so the same class is picked on every backend (row order is not
+    # guaranteed and differs between 4store/AG/GraphDB/Virtuoso).
+    candidates = []
     LinkedData::Models::Class.in(os).include(parents: [:prefLabel]).page(1, 500).each do |cls|
       next if cls.parents.nil? || cls.parents.empty?
 
-      parent = cls.parents.first
-      parent.bring(:parents) if parent.bring?(:parents)
-      next unless parent.parents.nil? || parent.parents.empty?
+      cls.parents.each do |parent|
+        # owl:Thing has no parents either, but the traversal stops on it via the
+        # sentinel, so it does not exercise the empty-parents branch.
+        next if parent.id.to_s['#Thing']
 
-      target = LinkedData::Models::Class.find(cls.id).in(os).first
-      break
+        parent.bring(:parents) if parent.bring?(:parents)
+        next unless parent.parents.nil? || parent.parents.empty?
+
+        candidates << cls.id.to_s
+        break
+      end
     end
-    refute_nil target, 'expected an OBO class whose parent is parentless'
+    target_id = candidates.sort.first
+    refute_nil target_id, 'expected an OBO class whose parent is parentless'
+    target = LinkedData::Models::Class.find(RDF::URI.new(target_id)).in(os).first
 
     paths = target.paths_to_root
     refute_empty paths, 'expected at least one path to root'
 
+    saw_parentless_terminal = false
     paths.each do |path|
       refute_includes path, nil, 'path contains a nil node'
       assert_equal target.id.to_s, path.last.id.to_s, 'path must end at the requested class'
 
       root = path.first
       root.bring(:parents) if root.bring?(:parents)
-      assert_empty(root.parents || [],
-                   "path must terminate at a parentless class, got #{root.id}")
+      root_parents = root.parents || []
+      saw_parentless_terminal ||= root_parents.empty?
+
+      # A path may also stop on the owl:Thing sentinel, which owlapi asserts on
+      # top-level classes; what must hold is that nothing traversable is left.
+      assert_empty root_parents.reject { |p| p.id.to_s['#Thing'] },
+                   "path must terminate where no parent is left to follow, got #{root.id}"
     end
+
+    assert saw_parentless_terminal,
+           'expected at least one path to terminate at a class with no parents at all -- ' \
+           'that is the case that used to raise'
   end
 end

--- a/test/models/test_class.rb
+++ b/test/models/test_class.rb
@@ -454,4 +454,52 @@ class TestClassModel < LinkedData::TestOntologyCommon
     assert_equal String, xml_comment.class
     assert_equal comment, xml_comment
   end
+
+  # Companion to test_bro_paths_to_root, for the OBO tree property. BRO cannot
+  # cover this: owlapi asserts `rdfs:subClassOf owl:Thing` on top-level OWL
+  # classes, and the traversal treats owl:Thing as a stop sentinel. OBO
+  # submissions walk metadata:treeView, where no such sentinel exists, so the
+  # traversal has to terminate on a genuinely parentless ancestor instead.
+  # Regressing that recurses into an empty parents array and raises
+  # "undefined method `id' for nil:NilClass" in append_if_not_there_already.
+  def test_obo_paths_to_root_terminates_at_parentless_class
+    if !LinkedData::Models::Ontology.find("HPPATHSTEST").first
+      submission_parse("HPPATHSTEST", "HP paths_to_root test", "./test/data/ontology_files/hp.obo", 124,
+                       process_rdf: true, index_search: false,
+                       run_metrics: false)
+    end
+    os = LinkedData::Models::Ontology.find("HPPATHSTEST").first.latest_submission(status: [:rdf])
+
+    assert_equal 'http://data.bioontology.org/metadata/treeView',
+                 LinkedData::Models::Class.tree_view_property(os).to_s,
+                 'expected the OBO tree property, otherwise this duplicates the OWL test'
+
+    # Find a class whose own parent has no parents -- one hop is enough to make
+    # the traversal walk into the parentless ancestor.
+    target = nil
+    LinkedData::Models::Class.in(os).include(parents: [:prefLabel]).page(1, 500).each do |cls|
+      next if cls.parents.nil? || cls.parents.empty?
+
+      parent = cls.parents.first
+      parent.bring(:parents) if parent.bring?(:parents)
+      next unless parent.parents.nil? || parent.parents.empty?
+
+      target = LinkedData::Models::Class.find(cls.id).in(os).first
+      break
+    end
+    refute_nil target, 'expected an OBO class whose parent is parentless'
+
+    paths = target.paths_to_root
+    refute_empty paths, 'expected at least one path to root'
+
+    paths.each do |path|
+      refute_includes path, nil, 'path contains a nil node'
+      assert_equal target.id.to_s, path.last.id.to_s, 'path must end at the requested class'
+
+      root = path.first
+      root.bring(:parents) if root.bring?(:parents)
+      assert_empty(root.parents || [],
+                   "path must terminate at a parentless class, got #{root.id}")
+    end
+  end
 end

--- a/test/models/test_skos_submission.rb
+++ b/test/models/test_skos_submission.rb
@@ -217,6 +217,40 @@ SELECT ?children WHERE {
     assert seen_target, 'target class not found within its own tree'
   end
 
+  # Guards the terminal condition of the paths_to_root traversal. The traversal
+  # must stop when it reaches a class with no parents under the submission's tree
+  # property; it cannot rely on an owl:Thing sentinel, which never appears under
+  # skos:broader (or metadata:treeView for OBO), nor on `roots` -- the
+  # /classes/:cls/paths_to_root endpoint passes none. Regressing this recurses
+  # into an empty parents array and raises
+  # "undefined method `id' for nil:NilClass" in append_if_not_there_already.
+  def test_skos_paths_to_root_terminates_at_parentless_concept
+    sub = before_suite
+    roots = sub.roots
+    refute_empty roots, 'expected SKOS roots'
+
+    # Descend one level from a root so the path is non-trivial (root -> target).
+    target = nil
+    roots.each do |r|
+      LinkedData::Models::Class.in(sub).models([r]).include(children: [:prefLabel]).all
+      next if r.children.empty?
+
+      target = LinkedData::Models::Class.find(r.children.first.id).in(sub).first
+      break
+    end
+    refute_nil target, 'expected a SKOS root with at least one child'
+
+    paths = target.paths_to_root
+    refute_empty paths, 'expected at least one path to root'
+
+    root_ids = roots.map { |r| r.id.to_s }
+    paths.each do |path|
+      refute_includes path, nil, 'path contains a nil node'
+      assert_equal target.id.to_s, path.last.id.to_s, 'path must end at the requested class'
+      assert_includes root_ids, path.first.id.to_s, 'path must start at a submission root'
+    end
+  end
+
   # N+1 guard for the class-tree endpoint (SKOS). Same contract as the OWL guard
   # in test_class.rb: serializing a tree must resolve the submission's languages
   # once, not once per node (get_languages `bring?` guard,

--- a/test/models/test_skos_submission.rb
+++ b/test/models/test_skos_submission.rb
@@ -230,25 +230,39 @@ SELECT ?children WHERE {
     refute_empty roots, 'expected SKOS roots'
 
     # Descend one level from a root so the path is non-trivial (root -> target).
-    target = nil
-    roots.each do |r|
+    # Ids are sorted so the same concept is picked on every backend -- row order
+    # is not guaranteed and differs between 4store/AG/GraphDB/Virtuoso.
+    child_ids = []
+    roots.sort_by { |r| r.id.to_s }.each do |r|
       LinkedData::Models::Class.in(sub).models([r]).include(children: [:prefLabel]).all
-      next if r.children.empty?
-
-      target = LinkedData::Models::Class.find(r.children.first.id).in(sub).first
-      break
+      child_ids += r.children.map { |c| c.id.to_s }
     end
-    refute_nil target, 'expected a SKOS root with at least one child'
+    target_id = child_ids.sort.first
+    refute_nil target_id, 'expected a SKOS root with at least one child'
+    target = LinkedData::Models::Class.find(RDF::URI.new(target_id)).in(sub).first
 
     paths = target.paths_to_root
     refute_empty paths, 'expected at least one path to root'
 
-    root_ids = roots.map { |r| r.id.to_s }
+    saw_parentless_terminal = false
     paths.each do |path|
       refute_includes path, nil, 'path contains a nil node'
       assert_equal target.id.to_s, path.last.id.to_s, 'path must end at the requested class'
-      assert_includes root_ids, path.first.id.to_s, 'path must start at a submission root'
+
+      root = path.first
+      root.bring(:parents) if root.bring?(:parents)
+      root_parents = root.parents || []
+      saw_parentless_terminal ||= root_parents.empty?
+
+      # skos:broader has no owl:Thing sentinel, so the only way to stop is to run
+      # out of parents; the reject keeps this symmetric with the OBO guard.
+      assert_empty root_parents.reject { |p| p.id.to_s['#Thing'] },
+                   "path must terminate where no parent is left to follow, got #{root.id}"
     end
+
+    assert saw_parentless_terminal,
+           'expected at least one path to terminate at a concept with no broader -- ' \
+           'that is the case that used to raise'
   end
 
   # N+1 guard for the class-tree endpoint (SKOS). Same contract as the OWL guard


### PR DESCRIPTION
## Problem

`/ontologies/:acr/classes/:cls/paths_to_root` returns 500 in production (reported for NDFRT, RCD, NCBITAXON, CL, etc):

```
NoMethodError - undefined method `id' for nil:NilClass
  models/class.rb:701:in `append_if_not_there_already'
  models/class.rb:725:in `traverse_path_to_root'
  ... recursion via 746 / 728 ...
  concerns/concepts/concept_tree.rb:64:in `paths_to_root'
```

`traverse_path_to_root` gated its empty-parents guard on the `tree` flag:

```ruby
return if (tree && parents.length == 0)
```

so the terminal condition was only checked in single-spine mode. The `paths_to_root` endpoint calls with `tree: false` and no `roots`, which leaves `owl:Thing` as the only stop sentinel the traversal recognizes (`append_if_not_there_already`, `tree_root?`). When the climb reaches a class with no parents under the submission's tree property, goo loads `parents` as `[]` *and* marks it loaded (`solutions_mapper.rb` `init_unloaded_attributes`), so the `loaded_attributes.include?(:parents)` fail-safe does not catch it, the recursion is entered with an empty array, and `parents[0]` is nil.

## Scope

The trigger is not ontology-specific: the ancestor chain reaches a class with zero parents under that submission's tree property, and that class is not `owl:Thing`.

- **SKOS** (`skos:broader`) and **OBO** (`metadata:treeView`) have no `owl:Thing` equivalent under the tree property, so every class *that has a parent* is affected.
- **OWL** mostly escapes it because owlapi asserts `rdfs:subClassOf owl:Thing` on top-level classes (12 such triples in a `BRO_v3.2.owl` parse, none present in the source file), and that is the sentinel the traversal already handles.
- Root classes were never affected — `paths_to_root` returns `[]` before traversing.
- `/tree` was never affected — `path_to_root` passes `tree: true` *and* real `roots`, so it stops both at the old guard and in `tree_root?`.
- Provisional classes hit the same code via `ProvisionalClass#traverse_path_to_root` -> `cls.paths_to_root`, inside `index_doc`. There it is swallowed by a `rescue Exception` and the document is indexed with empty `path_ids`, so affected submissions have been indexing provisional classes without ancestor paths.

## Who calls this endpoint

`paths_to_root` traffic is mostly BioMixer, which is why the failures show up in the API log and New Relic with no visible symptom in the portal.

The BioPortal UI has no server-side call path to it at all: `ontologies_api_ruby_client` has no `paths_to_root` wrapper, and the only two references in `bioportal_web_ui` both hand the work to BioMixer rather than calling the API themselves — `app/views/concepts/_biomixer.html.erb:4` (the concept page's Visualization tab) and `public/widgets/visualization/index.html:32` (the embeddable widget). Both build an iframe `src` of `$BIOMIXER_URL/?mode=embed&embed_mode=paths_to_root&…&restURLPrefix=<api>`, so the request is issued by BioMixer's JavaScript in the visitor's browser, straight against the API. Rails never sees the response: a 500 there produces no error page and no flash, just an empty visualization inside a third-party iframe on a secondary tab someone has to click. Everything the portal itself uses for hierarchy browsing goes through `/tree`, `/children` and `/parents`, none of which enter the broken branch.

The remainder is direct API clients; the reported URLs look like scripted traversal across NDFRT, RCD and NCBITAXON. Traffic attribution was not measured here — grouping the New Relic errors by referer and user agent would confirm the split.

## Changes

- Make the terminal guard unconditional. A parentless ancestor ends that path; the path built so far is already correct. This matches `OntologyProperty#traverse_path_to_root`, a near-copy of the same algorithm that has always used an unconditional `return if parents.empty?` — the `tree &&` in `Class` was the outlier.
- Nil-safe `.dup` on `p.parents` (goo nils `@parents` before re-querying in `bring`, and `.dup` raises before the entry guard can help).
- The cannot-load-parents fail-safe used `return`, which aborted the remaining `recursions.each_index` iterations and silently truncated the *sibling* paths cloned for a multi-parent class. Now `next`, so only the offending path stops.

## Tests

Two regression tests, both verified to raise the production `NoMethodError` against the pre-fix traversal:

- `test_skos_paths_to_root_terminates_at_parentless_concept` — SKOS, `efo_gwas.skos.owl` fixture
- `test_obo_paths_to_root_terminates_at_parentless_class` — OBO, `hp.obo` fixture, with an assertion that the tree property really is `metadata:treeView` so it cannot silently degrade into a duplicate of the existing OWL test

Both select their subject deterministically (sorted ids) rather than taking the first row, since row order differs per backend, skip `owl:Thing` when looking for a parentless parent, and assert both that no traversable parent is left at the terminal node and that at least one path terminates at a class with no parents at all. Green on 4store, AllegroGraph, GraphDB and Virtuoso.

## Notes for the reviewer

- `ontology_property.rb:331` has the same `return`-instead-of-`next` truncation. It cannot crash there (guarded at 299 and 334), so it is deliberately left out of this PR.
- The same unfixed guard exists upstream in `agroportal/ontologies_linked_data` (`class.rb:572`) and `ontoportal/ontologies_linked_data` (`class.rb:546`), with `paths_to_root` called without `roots` in both `ontologies_api` forks. Worth reporting upstream; AgroPortal is SKOS-heavy and therefore the most exposed.
- `Class` and `OntologyProperty` carry two copies of this traversal with ~22 identical lines and four small points of variation (stop sentinel, skip rule, parent attributes to bring, fail-safe). The duplication is why the correct guard sat in the repo without helping. Consolidating behind a shared concern is a reasonable follow-up, gated on adding property-side path coverage first — today the only property tree assertion in the suite is `test_ontology.rb:234`.
- ncbo/ontologies_linked_data#312 was filed separately for the OWLAPI reasoning flag, found while investigating this (the reasoner turned out to be unrelated to this crash).

