### PR TITLE
Extract & persist IAO:0000700 as hasOntologyRootTerm

### DIFF
--- a/config/schemes/ontology_submission.yml
+++ b/config/schemes/ontology_submission.yml
@@ -1410,6 +1410,17 @@ translationOfWork:
   extractedMetadata: true
   metadataMappings: [ "adms:translation", "schema:translationOfWork" ]
 
+#Ontology root term(s)
+hasOntologyRootTerm:
+  display: "relations"
+  label: "Ontology root term(s)"
+  helpText: "Class(es) the ontology declares as its display roots, used to start the class hierarchy below owl:Thing and upper-ontology terms."
+  example: 'http://purl.obolibrary.org/obo/CL_0000000'
+  description: [
+    "IAO: Relates an ontology to a term that is a designated root term of the ontology; display tools can use these as the starting point when rendering the class hierarchy. There can be more than one." ]
+  extractedMetadata: true
+  metadataMappings: [ "obo_purl:IAO_0000700" ]
+
 ### Content
 
 #Identifier pattern

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -147,6 +147,12 @@ module LinkedData
       attribute :usedBy, namespace: :voaf, type: %i[uri list]
       attribute :workTranslation, namespace: :schema, type: %i[uri list]
       attribute :translationOfWork, namespace: :schema, type: %i[uri list]
+      # Class(es) the ontology declares as display roots via IAO:0000700. No
+      # namespace: the source property has a numeric local name (IAO_0000700), so
+      # it is stored under the default :metadata namespace and read from the source
+      # IRI via metadataMappings in config/schemes/ontology_submission.yml (same
+      # pattern as obsoleteParent).
+      attribute :hasOntologyRootTerm, type: %i[list uri]
 
       # Content metadata
       attribute :uriRegexPattern, namespace: :void

--- a/test/data/ontology_files/custom_root_terms.owl
+++ b/test/data/ontology_files/custom_root_terms.owl
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY obo "http://purl.obolibrary.org/obo/" >
+    <!ENTITY msotes "http://bioportal.bioontology.org/ontologies/msotes#" >
+]>
+
+
+<rdf:RDF xmlns="http://bioportal.bioontology.org/ontologies/msotes#"
+     xml:base="http://bioportal.bioontology.org/ontologies/msotes"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:msotes="http://bioportal.bioontology.org/ontologies/msotes#">
+
+    <!-- The ontology declares two display roots via IAO:0000700 (has ontology
+         root term): class1 and class2. class1 is a true top; class2 is nested
+         under class1, so this also exercises "declared root that is not a
+         structural owl:Thing child". -->
+    <owl:Ontology rdf:about="http://bioportal.bioontology.org/ontologies/msotes">
+        <obo:IAO_0000700 rdf:resource="&msotes;class1"/>
+        <obo:IAO_0000700 rdf:resource="&msotes;class2"/>
+    </owl:Ontology>
+
+    <!-- IAO:0000700 as an annotation property (so the source is well-formed). -->
+    <owl:AnnotationProperty rdf:about="&obo;IAO_0000700"/>
+
+    <owl:Class rdf:about="&msotes;class1">
+        <rdfs:label>class 1</rdfs:label>
+    </owl:Class>
+
+    <owl:Class rdf:about="&msotes;class2">
+        <rdfs:subClassOf rdf:resource="&msotes;class1"/>
+        <rdfs:label>class 2</rdfs:label>
+    </owl:Class>
+
+    <owl:Class rdf:about="&msotes;class3">
+        <rdfs:subClassOf rdf:resource="&msotes;class1"/>
+        <rdfs:label>class 3</rdfs:label>
+    </owl:Class>
+</rdf:RDF>

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -308,6 +308,37 @@ SELECT DISTINCT * WHERE {
     assert_equal ['La première ontologie déddiée aux concepts de la médecine associée'], sub.notes
   end
 
+  # IAO:0000700 ("has ontology root term") declared on the ontology is extracted
+  # into the submission's hasOntologyRootTerm attribute (a list of class URIs).
+  def test_extract_ontology_root_terms
+    submission_parse("ROOTTERMS", "Root terms TEST",
+                     "./test/data/ontology_files/custom_root_terms.owl", 1,
+                     process_rdf: true, extract_metadata: true)
+
+    sub = LinkedData::Models::OntologySubmission
+          .where(ontology: [acronym: "ROOTTERMS"], submissionId: 1)
+          .include(:hasOntologyRootTerm).first
+    refute_nil sub
+
+    roots = Array(sub.hasOntologyRootTerm).map(&:to_s).sort
+    assert_equal ["http://bioportal.bioontology.org/ontologies/msotes#class1",
+                  "http://bioportal.bioontology.org/ontologies/msotes#class2"],
+                 roots
+  end
+
+  # An ontology without IAO:0000700 leaves hasOntologyRootTerm empty (not an error).
+  def test_extract_ontology_root_terms_absent
+    submission_parse("NOROOTTERMS", "No root terms TEST",
+                     "./test/data/ontology_files/custom_properties.owl", 1,
+                     process_rdf: true, extract_metadata: true)
+
+    sub = LinkedData::Models::OntologySubmission
+          .where(ontology: [acronym: "NOROOTTERMS"], submissionId: 1)
+          .include(:hasOntologyRootTerm).first
+    refute_nil sub
+    assert_empty Array(sub.hasOntologyRootTerm)
+  end
+
   def test_generate_language_preflabels
     submission_parse("D3OTEST", "DSMZ Digital Diversity Ontology Test",
                      "./test/data/ontology_files/d3o.owl", 1,


### PR DESCRIPTION
Closes #315. Part of the ontology-root-terms feature tracked in ncbo/bioportal-project#218.

Read an ontology's declared root terms (`IAO:0000700`, "has ontology root term") at submission-processing time and store them as a submission attribute `hasOntologyRootTerm`, so consumers can start the class hierarchy at the declared roots instead of `owl:Thing`. This exposes the metadata only — it does not change the roots computation.

## Changes

- **`config/schemes/ontology_submission.yml`** — declare `hasOntologyRootTerm` as an extractable attribute mapped to `obo_purl:IAO_0000700`. The `obo_purl` prefix (`http://purl.obolibrary.org/obo/`) is already registered in `Goo.namespaces`, so no namespace is added.
- **`lib/ontologies_linked_data/models/ontology_submission.rb`** — `attribute :hasOntologyRootTerm, type: %i[list uri]`. No namespace: the source property has a numeric local name (`IAO_0000700`), so it is stored under the default `:metadata` namespace and read from the source IRI via `metadataMappings` — the same pattern as `obsoleteParent`.
- **Tests + fixture** (`custom_root_terms.owl`) — extraction of one or more declared roots, and the absent case (empty value, not an error).

The existing `submission_extract_metadata` operation queries with the ontology IRI as subject and handles list/uri attributes, so no new extraction code was needed. The attribute is kept out of the `content_metadata_attributes` reject list so it appears in the API catalog and the (data-driven) submission edit form; the `user_provided_value` guard preserves a manually set value across re-processing.

## Testing

Tests pass against the 4store backend: `2 runs, 15 assertions, 0 failures, 0 errors, 0 skips`.

## Notes

- This does not change `/roots`. Teaching `/roots` to prefer declared roots is a separate, optional step (P4 in #218).
- The UI change (root-mode selector in the class tree and entity graph) is tracked in ncbo/bioportal_web_ui#548 and depends on this.
